### PR TITLE
docs: update README with repository overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,35 @@
 # dotfiles
 
+macOS の開発環境を chezmoi で管理する dotfiles。
+
+## 管理対象
+
+- Shell (zsh, starship, sheldon, zoxide, fzf)
+- Editor (vim, helix)
+- Terminal (ghostty, tmux)
+- Git (gitconfig, gitignore)
+- Claude Code (CLAUDE.md, agents, rules, plugins)
+- macOS (Brewfile, defaults)
+- Dev tools (mise, gh, yazi, zellij)
+
+## Prerequisites
+
+- macOS
+- [Homebrew](https://brew.sh)
+
 ## Setup
 
 ```sh
+# Homebrew をインストール（未導入の場合）
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+
+# chezmoi で dotfiles を適用
 brew install chezmoi
 chezmoi init --apply tanimon
 ```
+
+初回実行時に `profile` (work/personal) と `ghOrg` の入力を求められる。
+
+## License
+
+MIT


### PR DESCRIPTION
## Summary

- リポジトリの概要（1行説明）を追加
- 管理対象カテゴリを一覧化（Shell, Editor, Terminal, Git, Claude Code, macOS, Dev tools）
- Prerequisites セクションを追加
- Setup 手順にコメント付与、初回プロンプト（profile / ghOrg）の説明を追加
- License セクションを追加

## Test plan

- [ ] README.md の内容が正確か確認
- [ ] chezmoi init 手順が動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)