### PR TITLE
chore: sync enabledPlugins and extraKnownMarketplaces from target settings

### DIFF
--- a/dot_claude/settings.json.tmpl
+++ b/dot_claude/settings.json.tmpl
@@ -200,9 +200,18 @@
     "gopls-lsp@claude-plugins-official": true,
     "feature-dev@claude-plugins-official": false,
     "everything-claude-code@everything-claude-code": false,
-    "compound-engineering@every-marketplace": true,
     "commit-commands@claude-plugins-official": true,
-    "claude-delegator@jarrodwatts-claude-delegator": false
+    "claude-delegator@jarrodwatts-claude-delegator": false,
+    "compound-engineering@compound-engineering-plugin": true,
+    "ralph-loop@claude-plugins-official": true
+  },
+  "extraKnownMarketplaces": {
+    "compound-engineering-plugin": {
+      "source": {
+        "source": "github",
+        "repo": "EveryInc/compound-engineering-plugin"
+      }
+    }
   },
   "sandbox": {
     "enabled": true,


### PR DESCRIPTION
## Summary
- `enabledPlugins`: `compound-engineering@every-marketplace` → `compound-engineering@compound-engineering-plugin` に更新
- `enabledPlugins`: `ralph-loop@claude-plugins-official` を追加
- `extraKnownMarketplaces` セクションを新規追加

## Test plan
- [x] `chezmoi diff ~/.claude/settings.json` で `enabledPlugins` / `extraKnownMarketplaces` に差分がないことを確認