### PR TITLE
fix: sync extraKnownMarketplaces with actual plugin registrations

### DIFF
--- a/dot_claude/settings.json.tmpl
+++ b/dot_claude/settings.json.tmpl
@@ -210,6 +210,38 @@
       "source": {
         "source": "github",
         "repo": "EveryInc/compound-engineering-plugin"
+      },
+      "autoUpdate": true
+    },
+    "everything-claude-code": {
+      "source": {
+        "source": "github",
+        "repo": "affaan-m/everything-claude-code"
+      }
+    },
+    "claude-plugins-official": {
+      "source": {
+        "source": "github",
+        "repo": "anthropics/claude-plugins-official"
+      }
+    },
+    "anthropic-agent-skills": {
+      "source": {
+        "source": "github",
+        "repo": "anthropics/skills"
+      },
+      "autoUpdate": true
+    },
+    "jarrodwatts-claude-delegator": {
+      "source": {
+        "source": "github",
+        "repo": "jarrodwatts/claude-delegator"
+      }
+    },
+    "planning-with-files": {
+      "source": {
+        "source": "github",
+        "repo": "OthmanAdi/planning-with-files"
       }
     }
   },


### PR DESCRIPTION
## Summary
- Source template `dot_claude/settings.json.tmpl` was missing 5 marketplace entries and 1 `autoUpdate` flag that existed in the target `~/.claude/settings.json`
- Added: `everything-claude-code`, `claude-plugins-official`, `anthropic-agent-skills`, `jarrodwatts-claude-delegator`, `planning-with-files`
- Added `autoUpdate: true` to `compound-engineering-plugin` and `anthropic-agent-skills`

## Test plan
- [x] `chezmoi diff -- ~/.claude/settings.json` shows no diff after the change