### PR TITLE
fix: allow cco --safe sandbox to read claude binary path

### DIFF
--- a/docs/solutions/runtime-errors/cco-safe-mode-claude-not-found-in-path.md
+++ b/docs/solutions/runtime-errors/cco-safe-mode-claude-not-found-in-path.md
@@ -1,0 +1,41 @@
+---
+title: "cco --safe mode: claude not found in PATH"
+category: runtime-errors
+date: 2026-03-17
+tags: [cco, sandbox, seatbelt, safe-mode, path]
+---
+
+## Problem
+
+Running `claude` (via cco shell function) with `--safe` mode produces:
+
+```
+▶ Starting cco with native sandbox...
+▶ Adding additional directory: /Users/.../ghq
+Error: claude not found in PATH
+```
+
+## Root Cause
+
+cco's `--safe` mode generates a Seatbelt policy that denies **all** `file-read*` under `$HOME`, then selectively re-allows specific paths. The `claude` binary at `~/.local/bin/claude` (symlink → `~/.local/share/claude/versions/<ver>`) falls under the blanket deny, so the sandbox cannot read or execute it.
+
+## Solution
+
+Add the claude binary paths as **read-only** entries in `~/.config/cco/allow-paths` (chezmoi source: `dot_config/cco/allow-paths.tmpl`):
+
+```
+{{ .chezmoi.homeDir }}/.local/bin:ro
+{{ .chezmoi.homeDir }}/.local/share/claude:ro
+```
+
+The `:ro` suffix causes cco to pass these as `--read-only` to the sandbox script, which generates `(allow file-read* (subpath ...))` Seatbelt rules — sufficient for binary execution without granting write access.
+
+## Prevention
+
+When adding new tools to cco's `--safe` sandbox, verify the tool's binary location is readable. Check with:
+
+```bash
+readlink -f $(which <tool>)  # resolve full symlink chain
+```
+
+If any path in the chain is under `$HOME`, add it as `:ro` in `allow-paths`.

--- a/dot_config/cco/allow-paths.tmpl
+++ b/dot_config/cco/allow-paths.tmpl
@@ -2,3 +2,6 @@
 # These are passed as --add-dir arguments to cco
 # Append :ro for read-only access (default is :rw)
 {{ .chezmoi.homeDir }}/ghq
+# Allow sandbox to read/execute the claude binary
+{{ .chezmoi.homeDir }}/.local/bin:ro
+{{ .chezmoi.homeDir }}/.local/share/claude:ro


### PR DESCRIPTION
## Summary

- cco の `--safe` モードで `claude not found in PATH` エラーが発生する問題を修正
- `--safe` モードの Seatbelt ポリシーが `$HOME` 以下の全 `file-read*` を拒否するため、`~/.local/bin/claude` および `~/.local/share/claude/` のバイナリが読み取れなかった
- `allow-paths.tmpl` に `:ro` エントリを追加し、サンドボックスがバイナリを読み取り・実行できるようにした

## Test plan

- [x] `chezmoi apply` で `~/.config/cco/allow-paths` に新しいパスが反映されることを確認
- [x] `CCO_DEBUG=1` で sandbox コマンドに `--read-only` パスが含まれることを確認
- [x] cco 経由で claude が正常に起動することを確認