### PR TITLE
fix: sync settings.json source with target state

### DIFF
--- a/dot_claude/settings.json.tmpl
+++ b/dot_claude/settings.json.tmpl
@@ -190,7 +190,7 @@
   },
   "statusLine": {
     "type": "command",
-    "command": "bash $HOME/.claude/scripts/statusline-wrapper.sh"
+    "command": "node --experimental-strip-types $HOME/.claude/statusline-command.ts"
   },
   "enabledPlugins": {
     "superpowers@claude-plugins-official": true,
@@ -262,5 +262,6 @@
     "excludedCommands": [
       "docker"
     ]
-  }
+  },
+  "skipDangerousModePermissionPrompt": true
 }


### PR DESCRIPTION
## Summary

- Update `statusLine.command` from `bash statusline-wrapper.sh` to `node --experimental-strip-types statusline-command.ts` to match deployed target
- Add `skipDangerousModePermissionPrompt: true` to match deployed target

These drift fixes prevent unintended overwrites on `chezmoi apply`.

## Test plan

- [x] Run `chezmoi diff` and confirm no unexpected changes to `~/.claude/settings.json`
- [x] Verify `chezmoi apply` only applies intended changes