### PR TITLE
feat: add gtr-copy for interactive worktree file copying

### DIFF
--- a/dot_local/bin/executable_gtr-copy
+++ b/dot_local/bin/executable_gtr-copy
@@ -27,10 +27,10 @@ selected_files=$(
         git ls-files --others --exclude-standard
     } |
         sort -u |
-        fzf --multi --preview 'f={}; bat --color=always -- "$f" 2>/dev/null || cat -- "$f"'
+        fzf --multi --header 'Select files to copy (Tab: toggle, Enter: confirm)' --preview 'f={}; bat --color=always -- "$f" 2>/dev/null || cat -- "$f"'
 ) || exit 0
 
-dest_line=$(printf '%s\n' "$destinations" | fzf) || exit 0
+dest_line=$(printf '%s\n' "$destinations" | fzf --header 'Select destination worktree') || exit 0
 dest_worktree=$(printf '%s\n' "$dest_line" | awk '{print $1}')
 
 copied=0


### PR DESCRIPTION
## Summary

- fzf を使って git worktree 間でファイルをインタラクティブにコピーするシェルスクリプト `gtr-copy` を追加
- `chezmoi apply` で `~/.local/bin/gtr-copy` に実行権限付きで配置
- tracked + untracked ファイルの一覧表示、bat/cat によるプレビュー、ディレクトリ構造の保持に対応

## Usage

```bash
# worktree 内で実行
gtr-copy
# 1. fzf でコピーしたいファイルを Tab で複数選択 → Enter
# 2. fzf でコピー先 worktree を選択 → Enter
```

## Test plan

- [ ] worktree 内で `gtr-copy` を実行し、fzf でファイル選択 → コピー先選択でファイルがコピーされる
- [ ] 未コミットファイルが fzf 一覧に表示される
- [x] fzf キャンセル（Esc）でクリーンに終了する
- [x] git リポジトリ外で実行すると明確なエラーが出る
- [x] `chezmoi apply` で `~/.local/bin/gtr-copy` に正しく配置される

🤖 Generated with [Claude Code](https://claude.com/claude-code)