### PR TITLE
docs: add directory layout and cco integration to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,7 @@ Defined in `.chezmoi.toml.tmpl`, prompted on first `chezmoi init`:
 
 **`run_onchange_` scripts** — Track file hashes in comments (e.g., `# brewfile hash: {{ include "darwin/Brewfile" | sha256sum }}`). They re-run only when the tracked content changes.
 
-**cco (Claude Code Offline) integration** — `.chezmoiexternal.toml` pulls the cco repo into `~/.local/share/cco`. `run_onchange_after_link-cco.sh.tmpl` symlinks the `cco` binary, and `run_onchange_after_patch-cco-sandbox.sh.tmpl` patches the macOS Seatbelt sandbox profile for Node.js compatibility.
+**cco (Claude Condom) integration** — `.chezmoiexternal.toml` pulls the cco repo into `~/.local/share/cco`. `run_onchange_after_link-cco.sh.tmpl` symlinks the `cco` binary, and `run_onchange_after_patch-cco-sandbox.sh.tmpl` patches the macOS Seatbelt sandbox profile for Node.js compatibility.
 
 ### `.chezmoiignore`
 


### PR DESCRIPTION
## Summary
- Architecture セクションに **Directory Layout** テーブルを追加（`darwin/`, `windows/`, `.chezmoiscripts/`, `dot_claude/`, `scripts/`）
- Key Patterns セクションに **cco integration** の説明を追加（external repo pull + symlink + Seatbelt sandbox patch）
- CLAUDE.md Improver による品質監査の結果、未文書化だった領域を補完

## Test plan
- [ ] CLAUDE.md の内容が実際のディレクトリ構成と一致していることを確認
- [ ] `chezmoi apply --dry-run` でエラーがないことを確認