### PR TITLE
feat: add update-brewfile.sh script

### DIFF
--- a/scripts/update-brewfile.sh
+++ b/scripts/update-brewfile.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+TARGET="${REPO_ROOT}/darwin/Brewfile"
+
+if ! command -v brew &>/dev/null; then
+    echo "error: brew not found" >&2
+    exit 1
+fi
+
+brew bundle dump --force --file="$TARGET"
+
+echo "Updated ${TARGET} ($(wc -l <"$TARGET" | tr -d ' ') entries)"


### PR DESCRIPTION
## Summary
- `scripts/update-brewfile.sh` を追加: `brew bundle dump --force` で `darwin/Brewfile` を再生成するヘルパースクリプト
- 既存の `update-gh-extensions.sh` / `update-marketplaces.sh` と同一パターンに準拠
- 宣言的同期パターンの Brewfile 版 capture スクリプトとして、欠落していたピースを補完

## Test plan
- [x] `bash scripts/update-brewfile.sh` を実行し、`darwin/Brewfile` が再生成されることを確認
- [x] 出力に `Updated ... (N entries)` が表示されることを確認
- [ ] `brew` 未インストール環境でエラーメッセージが stderr に出力されることを確認