### PR TITLE
feat: add /ce:compound reminder to harness activator

### DIFF
--- a/dot_claude/scripts/executable_harness-activator.sh
+++ b/dot_claude/scripts/executable_harness-activator.sh
@@ -59,8 +59,8 @@ harness improvements are needed:
 2. Did a repeated failure pattern emerge (same error 3+ times)?
    → Run /capture-harness-feedback to create preventive rules
 
-3. Was significant debugging or investigation required?
-   → The solution may be worth documenting in docs/solutions/
+3. Was a non-trivial problem solved during this session?
+   → Run /ce:compound to document the solution in docs/solutions/
 
 Only act if improvements are clearly warranted. No action needed
 for routine, successful sessions.


### PR DESCRIPTION
## Summary
- harness-activator.sh のリマインダー項目3を `/ce:compound` スキルへの誘導に書き換え
- 曖昧な「docs/solutions/ に記録を検討」→ 具体的な `/ce:compound` コマンド実行指示に変更
- セッション中に解決した非自明な問題の知識が構造化ドキュメントとして蓄積されやすくなる

## Changes
- `dot_claude/scripts/executable_harness-activator.sh`: heredoc 内のテキスト2行のみ変更（bash ロジック変更なし）

## Test plan
- [x] shellcheck パス
- [x] 既存の項目1, 2 のフォーマットとの一貫性確認
- [x] スクリプトロジック（session flag, context guards）変更なし確認