### PR TITLE
fix: align CI shellcheck/shfmt with pre-commit and add modify_ smoke tests

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,8 +28,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Run shellcheck
         run: |
-          find . -type f \( -name '*.sh' -o -name '*.bash' \) \
-            ! -name '*.tmpl' \
+          find . -type f \( -name '*.sh' -o -name '*.bash' -o -name 'executable_*' \) \
+            ! -name '*.tmpl' ! -name '*.mts' ! -name '*.ts' ! -name '*.mjs' \
             ! -path './node_modules/*' \
             -print0 | xargs -0 -r shellcheck
 
@@ -45,10 +45,41 @@ jobs:
           chmod +x /usr/local/bin/shfmt
       - name: Run shfmt
         run: |
-          find . -type f \( -name '*.sh' -o -name '*.bash' \) \
-            ! -name '*.tmpl' \
+          find . -type f \( -name '*.sh' -o -name '*.bash' -o -name 'executable_*' \) \
+            ! -name '*.tmpl' ! -name '*.mts' ! -name '*.ts' ! -name '*.mjs' \
             ! -path './node_modules/*' \
             -print0 | xargs -0 -r shfmt -d -i 4
+
+  modify-scripts:
+    name: modify_ script smoke tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Test modify_dot_claude.json with existing data
+        run: |
+          export CHEZMOI_SOURCE_DIR="$(pwd)"
+          output=$(printf '{"existingKey":"value","mcpServers":{}}' | bash modify_dot_claude.json)
+          echo "$output" | jq empty || { echo "::error::Output is not valid JSON"; exit 1; }
+          echo "$output" | jq -e '.existingKey == "value"' > /dev/null || { echo "::error::existingKey not preserved"; exit 1; }
+          echo "$output" | jq -e '.mcpServers | has("notion")' > /dev/null || { echo "::error::mcpServers not replaced from source"; exit 1; }
+          echo "PASS: existing data preserved, mcpServers replaced from source"
+      - name: Test modify_dot_claude.json with empty stdin
+        run: |
+          export CHEZMOI_SOURCE_DIR="$(pwd)"
+          output=$(printf '' | bash modify_dot_claude.json)
+          echo "$output" | jq empty || { echo "::error::Output is not valid JSON for empty stdin"; exit 1; }
+          echo "$output" | jq -e 'has("mcpServers")' > /dev/null || { echo "::error::mcpServers missing for empty stdin"; exit 1; }
+          echo "PASS: empty stdin produces valid JSON with mcpServers"
+      - name: Test modify_dot_claude.json with missing source file
+        run: |
+          export CHEZMOI_SOURCE_DIR="/tmp/nonexistent-dir"
+          input='{"existingKey":"keep","mcpServers":{"old":"data"}}'
+          output=$(printf '%s' "$input" | bash modify_dot_claude.json 2>/dev/null)
+          if [ "$output" != "$input" ]; then
+            echo "::error::Missing source file should passthrough stdin unchanged"
+            exit 1
+          fi
+          echo "PASS: missing source file passes through stdin"
 
   chezmoi-templates:
     name: chezmoi templates

--- a/docs/solutions/developer-experience/chezmoi-project-harness-rules-and-ci-2026-03-28.md
+++ b/docs/solutions/developer-experience/chezmoi-project-harness-rules-and-ci-2026-03-28.md
@@ -1,7 +1,7 @@
 ---
 title: "Project-Specific Harness Rules and CI for chezmoi Dotfiles Repository"
 date: 2026-03-28
-last_updated: 2026-03-28
+last_updated: 2026-03-29
 problem_type: developer_experience
 component: tooling
 symptoms:
@@ -75,6 +75,10 @@ Four parallel jobs: secretlint (via pnpm), shellcheck (Ubuntu pre-installed), sh
 
 **Critical pattern:** Both shellcheck and shfmt `find` commands exclude `.tmpl` files — Go template syntax is incompatible with shell linters. This mirrors the existing `.pre-commit-config.yaml` exclusion pattern.
 
+**`executable_*` coverage (2026-03-29):** The original CI `find` only matched `*.sh` and `*.bash`, missing chezmoi `executable_*` prefix files without extensions (e.g., `executable_git-clean-squashed`). Pre-commit caught these via regex `executable_` in `files:`, but CI silently skipped them. Fixed by adding `-name 'executable_*'` to both shellcheck and shfmt `find` commands, with additional exclusions for `.mts`, `.ts`, `.mjs` (TypeScript files that also use the `executable_` prefix).
+
+**`modify_` script smoke tests (2026-03-29):** Added a `modify-scripts` CI job that exercises `modify_dot_claude.json` with three test cases: (1) existing JSON with mcpServers replacement verified by checking for a known key from `mcp-servers.json`, (2) empty stdin producing valid JSON with mcpServers, (3) missing source file triggering passthrough of stdin unchanged. This catches regressions that could zero out `~/.claude.json` on `chezmoi apply`.
+
 **chezmoi template validation** uses `chezmoi execute-template --config <test-config> --source "$(pwd)"` to validate Go template syntax in all `.tmpl` files. Key details:
 - A test `chezmoi.toml` is created with `[data]` section providing dummy values for `profile` and `ghOrg`. This is required because `--init --promptString` only answers `promptStringOnce` prompts — it does NOT populate the `.data` namespace that templates reference via `.ghOrg` / `.profile`
 - `--source "$(pwd)"` is **required** for templates that use `include` — without it, `execute-template` cannot resolve file paths for hash computation
@@ -101,6 +105,8 @@ Added `.github/` to `.chezmoiignore` to prevent CI files from deploying to `~/`.
 - When adding project-specific agent rules to a chezmoi repo, always use `.claude/rules/` at the repo root — never add to `dot_claude/rules/` unless the rule should apply globally across all projects
 - When adding new repo-only directories (`.github/`, `scripts/`), always add them to `.chezmoiignore`
 - When setting up shell linting in CI for chezmoi repos, always exclude `.tmpl` files — reference `.pre-commit-config.yaml` for the established exclusion patterns
+- When aligning CI `find` with pre-commit regex patterns, watch for chezmoi `executable_*` prefix files — `find -name` and pre-commit `files:` regex use different matching semantics. Verify both produce the same file set with a local `find` command
+- Add smoke tests for `modify_` scripts in CI — a broken modify\_ script can silently zero out the target file on `chezmoi apply`. Test with sample input, empty stdin, and missing source file scenarios
 - When using `chezmoi execute-template` in CI, use `--config` with a test `chezmoi.toml` containing `[data]` section — `--init --promptString` does NOT populate the data namespace. Also pass `--source` for `include` resolution. Exclude `.chezmoi.toml.tmpl` from validation
 - When adding project rules, include concrete file path references to real repository examples — agents follow patterns better when they can read the actual implementation
 - Remember that `docs/plans/` is gitignored — don't attempt to commit plan files

--- a/dot_local/bin/executable_git-clean-squashed
+++ b/dot_local/bin/executable_git-clean-squashed
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 usage() {
-  cat <<'USAGE'
+    cat <<'USAGE'
 Usage: git clean-squashed [options]
 
 Delete local branches that have been squash-merged into the base branch.
@@ -23,37 +23,59 @@ DRY_RUN=false
 NO_FETCH=false
 # Parse arguments
 while [[ $# -gt 0 ]]; do
-  case $1 in
+    case $1 in
     --base)
-      if [[ $# -lt 2 ]]; then
-        echo "Error: --base requires an argument" >&2; exit 1
-      fi
-      BASE_BRANCH="$2"; shift 2 ;;
-    --force) FORCE=true; shift ;;
-    --dry-run) DRY_RUN=true; shift ;;
-    --no-fetch) NO_FETCH=true; shift ;;
-    --help) usage; exit 0 ;;
-    *) echo "Unknown option: $1" >&2; usage >&2; exit 1 ;;
-  esac
+        if [[ $# -lt 2 ]]; then
+            echo "Error: --base requires an argument" >&2
+            exit 1
+        fi
+        BASE_BRANCH="$2"
+        shift 2
+        ;;
+    --force)
+        FORCE=true
+        shift
+        ;;
+    --dry-run)
+        DRY_RUN=true
+        shift
+        ;;
+    --no-fetch)
+        NO_FETCH=true
+        shift
+        ;;
+    --help)
+        usage
+        exit 0
+        ;;
+    *)
+        echo "Unknown option: $1" >&2
+        usage >&2
+        exit 1
+        ;;
+    esac
 done
 
 # Validate git repo
-git rev-parse --is-inside-work-tree &>/dev/null || { echo "Error: Not a git repository" >&2; exit 1; }
+git rev-parse --is-inside-work-tree &>/dev/null || {
+    echo "Error: Not a git repository" >&2
+    exit 1
+}
 
 # Determine base ref (prefer remote tracking branch, use fully-qualified refs)
 if git rev-parse --verify "refs/remotes/origin/$BASE_BRANCH" &>/dev/null; then
-  BASE_REF="origin/$BASE_BRANCH"
+    BASE_REF="origin/$BASE_BRANCH"
 elif git rev-parse --verify "refs/heads/$BASE_BRANCH" &>/dev/null; then
-  BASE_REF="$BASE_BRANCH"
+    BASE_REF="$BASE_BRANCH"
 else
-  echo "Error: Base branch '$BASE_BRANCH' not found" >&2
-  exit 1
+    echo "Error: Base branch '$BASE_BRANCH' not found" >&2
+    exit 1
 fi
 
 # Auto-fetch
 if [[ "$NO_FETCH" == false ]]; then
-  echo "Fetching from remote..."
-  git fetch --prune --quiet
+    echo "Fetching from remote..."
+    git fetch --prune --quiet
 fi
 
 # Get current branch and worktree branches
@@ -63,59 +85,59 @@ WORKTREE_BRANCHES=$(git worktree list --porcelain | grep '^branch ' | sed 's|^br
 # Scan for squash-merged branches
 CANDIDATES=()
 for branch in $(git for-each-ref refs/heads/ --format='%(refname:short)'); do
-  # Skip base branch
-  if [[ "$branch" == "$BASE_BRANCH" ]]; then continue; fi
-  # Skip current branch
-  if [[ "$branch" == "$CURRENT_BRANCH" ]]; then
-    echo "Skipping '$branch' (currently checked out)"
-    continue
-  fi
-  # Skip worktree branches
-  if echo "$WORKTREE_BRANCHES" | grep -qxF "$branch"; then
-    echo "Skipping '$branch' (checked out in another worktree)"
-    continue
-  fi
+    # Skip base branch
+    if [[ "$branch" == "$BASE_BRANCH" ]]; then continue; fi
+    # Skip current branch
+    if [[ "$branch" == "$CURRENT_BRANCH" ]]; then
+        echo "Skipping '$branch' (currently checked out)"
+        continue
+    fi
+    # Skip worktree branches
+    if echo "$WORKTREE_BRANCHES" | grep -qxF "$branch"; then
+        echo "Skipping '$branch' (checked out in another worktree)"
+        continue
+    fi
 
-  merge_base=$(git merge-base "$BASE_REF" "$branch" 2>/dev/null) || continue
-  squash_commit=$(git commit-tree "${branch}^{tree}" -p "$merge_base" -m _)
-  cherry_result=$(git cherry "$BASE_REF" "$squash_commit" 2>/dev/null) || continue
+    merge_base=$(git merge-base "$BASE_REF" "$branch" 2>/dev/null) || continue
+    squash_commit=$(git commit-tree "${branch}^{tree}" -p "$merge_base" -m _)
+    cherry_result=$(git cherry "$BASE_REF" "$squash_commit" 2>/dev/null) || continue
 
-  if [[ "$cherry_result" == "- $squash_commit" ]]; then
-    CANDIDATES+=("$branch")
-  fi
+    if [[ "$cherry_result" == "- $squash_commit" ]]; then
+        CANDIDATES+=("$branch")
+    fi
 done
 
 if [[ ${#CANDIDATES[@]} -eq 0 ]]; then
-  echo "No squash-merged branches found."
-  exit 0
+    echo "No squash-merged branches found."
+    exit 0
 fi
 
 # Display candidates
 echo ""
 echo "Squash-merged branches:"
 for branch in "${CANDIDATES[@]}"; do
-  last_commit=$(git log -1 --format='%ar' "$branch")
-  echo "  - $branch ($last_commit)"
+    last_commit=$(git log -1 --format='%ar' "$branch")
+    echo "  - $branch ($last_commit)"
 done
 echo ""
 
 if [[ "$DRY_RUN" == true ]]; then
-  echo "(dry-run: no branches deleted)"
-  exit 0
+    echo "(dry-run: no branches deleted)"
+    exit 0
 fi
 
 # Confirm deletion
 if [[ "$FORCE" == false ]]; then
-  read -rp "Delete ${#CANDIDATES[@]} branch(es)? [y/N] " confirm
-  if [[ "$confirm" != [yY] ]]; then
-    echo "Aborted."
-    exit 0
-  fi
+    read -rp "Delete ${#CANDIDATES[@]} branch(es)? [y/N] " confirm
+    if [[ "$confirm" != [yY] ]]; then
+        echo "Aborted."
+        exit 0
+    fi
 fi
 
 # Delete branches
 for branch in "${CANDIDATES[@]}"; do
-  git branch -D "$branch"
+    git branch -D "$branch"
 done
 
 echo "Done. Deleted ${#CANDIDATES[@]} branch(es)."


### PR DESCRIPTION
## Summary
- CI の shellcheck/shfmt `find` パターンに `executable_*` を追加し、pre-commit と対象ファイルを統一
- `modify_dot_claude.json` のスモークテストを CI に追加（既存データ、空stdin、source missing の3ケース）
- `executable_git-clean-squashed` の shfmt 自動フォーマット適用

## Test plan
- [x] ローカルで shellcheck/shfmt が `executable_*` ファイルを検出することを確認
- [x] `executable_notify.mts`（TypeScript）が正しく除外されることを確認
- [x] modify_ スモークテスト3件がローカルで PASS
- [x] secretlint, shellcheck, shfmt の pre-commit hooks が PASS
- [x] CI が全ジョブ PASS

🤖 Generated with [Claude Code](https://claude.ai/claude-code)