### PR TITLE
docs: close harness health documentation gaps

### DIFF
--- a/.claude/rules/renovate-external.md
+++ b/.claude/rules/renovate-external.md
@@ -1,0 +1,31 @@
+# Renovate + .chezmoiexternal.toml
+
+Rules for managing external dependencies in `.chezmoiexternal.toml` with Renovate auto-updates.
+
+## Renovate Contract
+
+The regex custom manager in `renovate.json` requires these three lines to be **strictly adjacent in order** — no blank lines, no reordering:
+
+```toml
+  url = "https://github.com/owner/repo.git"
+  # renovate: branch=main
+  ref = "full-sha-here"
+```
+
+Breaking this adjacency silently disables Renovate auto-updates for that entry.
+
+## Adding a New External Entry
+
+1. Add the TOML block with `url`, `# renovate: branch=<branch>`, and `ref` in order
+2. Pin `ref` to a full commit SHA (not a tag or branch name)
+3. Include `refreshPeriod` for chezmoi's own refresh cycle
+4. Verify Renovate detects the entry: check the Renovate dashboard or dry-run
+
+## Existing Entries
+
+See `.chezmoiexternal.toml` for current entries (Claudeception skill, cco).
+
+## Related
+
+- `renovate.json` — Renovate configuration with regex custom manager
+- `docs/solutions/integration-issues/chezmoi-external-script-repo-with-renovate-sha-pinning.md` — Detailed solution record

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,9 +61,7 @@ Extensively excludes `~/.claude/` dynamic directories (projects, sessions, cache
 
 ### `.chezmoiexternal.toml`
 
-Pulls external git repos (e.g., Claudeception skill, cco) into the managed tree with auto-refresh. Each entry is pinned to a commit SHA via `ref` for supply-chain safety. Renovate auto-updates these SHAs via a regex custom manager in `renovate.json`.
-
-**Renovate contract:** The regex requires `url`, `# renovate: branch=<branch>` comment, and `ref` lines to be strictly adjacent in order. Do not insert blank lines or reorder keys between them. When adding a new external entry, include the `# renovate: branch=` comment to enable auto-updates.
+Pulls external git repos (e.g., Claudeception skill, cco) into the managed tree with auto-refresh. Each entry is pinned to a commit SHA via `ref` for supply-chain safety. Renovate auto-updates these SHAs — see `.claude/rules/renovate-external.md` for the adjacency contract that must be preserved.
 
 ### Directory Layout
 
@@ -74,6 +72,7 @@ Pulls external git repos (e.g., Claudeception skill, cco) into the managed tree 
 | `.chezmoiscripts/` | All `run_onchange_` scripts live here (not in the source tree root) |
 | `dot_claude/` | Claude Code config (`~/.claude/`): settings, MCP servers, rules, agents, commands, plugins |
 | `scripts/` | Repo-only helper scripts (`update-marketplaces.sh`, `update-gh-extensions.sh`) |
+| `docs/solutions/` | Past problem resolutions — search here when encountering similar issues |
 
 ### Pre-commit Hooks
 
@@ -86,9 +85,12 @@ chezmoi apply --dry-run        # Preview changes before applying
 pnpm exec secretlint '**/*'   # Check for leaked secrets
 shellcheck <script.sh>         # Lint non-.tmpl shell scripts
 shfmt -d -i 4 <script.sh>     # Check shell script formatting
+
+# modify_ script smoke test (requires CHEZMOI_SOURCE_DIR)
+export CHEZMOI_SOURCE_DIR="$(pwd)" && printf '{"existingKey":"v","mcpServers":{}}' | bash modify_dot_claude.json | jq .
 ```
 
-Note: shellcheck and shfmt cannot lint `.tmpl` files (Go template syntax is incompatible).
+Note: shellcheck and shfmt cannot lint `.tmpl` files (Go template syntax is incompatible). For similar past issues, search `docs/solutions/`.
 
 ## Known Pitfalls
 


### PR DESCRIPTION
## Summary

- Add `modify_` smoke test command to CLAUDE.md Verification section for local testing
- Extract Renovate adjacency contract from CLAUDE.md into `.claude/rules/renovate-external.md` for better discoverability
- Add `docs/solutions/` to Directory Layout table and Verification note so agents discover past resolutions

Closes 3 documentation gaps identified by `/harness-health` (score 88/100).

## Test plan

- [ ] Verify `export CHEZMOI_SOURCE_DIR="$(pwd)" && printf '{"existingKey":"v","mcpServers":{}}' | bash modify_dot_claude.json | jq .` produces valid JSON
- [ ] Verify `.claude/rules/renovate-external.md` content matches `.chezmoiexternal.toml` structure
- [ ] Verify `docs/solutions/` appears in CLAUDE.md Directory Layout table
- [ ] Verify CLAUDE.md stays under 200 lines (currently 110)

🤖 Generated with [Claude Code](https://claude.com/claude-code)