### PR TITLE
feat: polish harness with pitfall categorization, hook tests, and rule promotion

### DIFF
--- a/.claude/rules/shell-scripts.md
+++ b/.claude/rules/shell-scripts.md
@@ -39,10 +39,51 @@ These rules are enforced automatically — not just advisory:
 
 - **CI** (`.github/workflows/lint.yml`): Each CI job calls `Makefile` targets directly — local and CI run the exact same commands
 - **Pre-commit** (`.pre-commit-config.yaml`): Runs shellcheck, shfmt, and secretlint automatically before each commit via prek
-- **Local** (`Makefile`): `make lint` runs all checks. Individual targets: `make shellcheck`, `make shfmt`, `make secretlint`, `make test-modify`, `make check-templates`
+- **Local** (`Makefile`): `make lint` runs all checks. Individual targets: `make shellcheck`, `make shfmt`, `make secretlint`, `make test-modify`, `make test-scripts`, `make check-templates`
 
 `.tmpl` files are excluded from shell linting because Go template syntax is incompatible with shell linters.
 
+
+## Hook Scripts
+
+Rules for Claude Code hook scripts (`dot_claude/scripts/`).
+
+### Exit Code Contract
+
+- `exit 0` — intentional skip (tool guard missing, non-project context, already ran)
+- `exit 1` + stderr message — actionable error
+- Never `exit 1` without stderr — produces confusing "No stderr output" message in Claude Code
+
+### Session Identity
+
+Extract session ID from stdin JSON (stable across all hook invocations in a session):
+
+```bash
+SESSION_ID=$(jq -r '.session_id // empty') || exit 0
+[[ -z "$SESSION_ID" ]] && exit 0
+```
+
+Do not use `$PPID` or `$$` — these are unreliable in `bash -c` hook wrappers.
+
+### One-Shot Flag Pattern
+
+For hooks that should fire only once per session:
+
+```bash
+FLAG_FILE="/tmp/claude-<hook-name>-${SESSION_ID}"
+[[ -f "$FLAG_FILE" ]] && exit 0
+
+# ... context guards (directory exclusions, git checks) ...
+
+# Set flag AFTER guards, not before — otherwise a non-project context
+# consumes the flag and the hook silently skips in project contexts later.
+touch "$FLAG_FILE"
+```
+
+### Reference
+
+- `docs/solutions/developer-experience/autonomous-harness-engineering-hooks-2026-03-28.md`
+- `docs/solutions/integration-issues/claude-code-hook-exit-code-and-stderr-semantics.md`
 
 ## Avoiding Recursion
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -47,6 +47,13 @@ jobs:
       - uses: actions/checkout@v4
       - run: make test-modify
 
+  harness-scripts:
+    name: harness script smoke tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: make test-scripts
+
   chezmoi-templates:
     name: chezmoi templates
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ chezmoi managed                # List all managed files
 chezmoi data                   # Show template data (profile, ghOrg, etc.)
 
 # Linting (mirrors CI — also runs on commit via prek)
-make lint                      # Run all checks (secretlint + shellcheck + shfmt + modify_ tests + templates)
+make lint                      # Run all checks (secretlint + shellcheck + shfmt + modify_ + script tests + templates)
 pnpm exec secretlint '**/*'   # Scan for leaked secrets only
 ```
 
@@ -90,6 +90,7 @@ make secretlint                # Scan for leaked secrets
 make shellcheck                # Lint non-.tmpl shell scripts
 make shfmt                     # Check shell script formatting (indent=4)
 make test-modify               # Smoke test modify_ scripts
+make test-scripts              # Smoke test harness scripts
 make check-templates           # Validate chezmoi .tmpl files
 ```
 
@@ -97,17 +98,28 @@ Note: shellcheck and shfmt cannot lint `.tmpl` files (Go template syntax is inco
 
 ## Known Pitfalls
 
+### chezmoi CLI & ファイル管理
+
 - **`chezmoi add --autotemplate` breaks JSON** — `:` and `/` get over-substituted. Use `chezmoi add --template` + manual `sed` for homeDir substitution instead.
 - **`run_after_` scripts calling `chezmoi add` cause recursion** — Use `cp` + `sed` to write directly to the source directory.
 - **`.chezmoiignore` silently skips** — If `chezmoi add` does nothing, check `.chezmoiignore`.
 - **`.chezmoiignore` `*.txt` is root-level only** — `*.txt` does NOT match nested paths like `.config/gh/extensions.txt`. Use `**/*.txt` for recursive matching, or add explicit entries for nested files. Always verify with `chezmoi managed | grep <pattern>`.
-- **Template escaping** — To output literal `{{ .chezmoi.homeDir }}` in a `.tmpl` file, use `{{ "{{ .chezmoi.homeDir }}" }}`.
-- **Git commit signing** — Requires 1Password SSH agent (`op-ssh-sign`). Commits will fail without it running.
 - **Repo-only files need `.chezmoiignore`** — Files like `CLAUDE.md`, `README.md` at repo root are excluded via `.chezmoiignore` so they don't deploy to `~/`. New repo-only files must be added there.
-- **`modify_` scripts: empty stdout = target deletion** — Never use OS guards (`{{ if eq .chezmoi.os "darwin" }}`); on non-matching OS the script outputs nothing and chezmoi zeros the file. Always include `set -e`. Use `printf '%s\n'` (not `printf '%s'`) to preserve trailing newlines stripped by `$(cat)`.
 - **Choosing chezmoi file patterns** — Regular `.tmpl` for fully-owned files. `create_` for provision-once. `modify_` for runtime-mutable files (IDE configs). `.chezmoiignore` to exclude entirely. For files modified by external tools (plugins), prefer `.chezmoiignore` + declarative `run_onchange_` scripts over bidirectional sync.
-- **`chezmoi execute-template` in CI needs config + source** — `--init --promptString` only answers `promptStringOnce` prompts; it does NOT populate the `.data` namespace (`.ghOrg`, `.profile`) that templates reference. Use a test `chezmoi.toml` with `[data]` section and pass `--config <path> --source "$(pwd)"`. Also exclude `.chezmoi.toml.tmpl` itself since it uses `promptStringOnce` (interactive).
-- **`docs/plans/` is gitignored** — `.gitignore` excludes `docs/*` with only `!docs/solutions/` as exception. Plan files created by `ce:plan` are local working documents and cannot be committed. Do not attempt to `git add` files under `docs/plans/` or modify `.gitignore` to include them without explicit user approval.
 - **Never edit deployed targets directly** — Always edit the chezmoi source file (under `~/.local/share/chezmoi/`), never the deployed target (under `~/`). For example, edit `dot_claude/scripts/executable_harness-activator.sh`, not `~/.claude/scripts/harness-activator.sh`. Changes to deployed targets are overwritten on next `chezmoi apply` and are not version-controlled. Use `chezmoi source-path <target>` to find the source file for any managed target.
-- **Inline hook commands: keep simple or use jq** — Inline `bash -c` hook commands in `settings.json.tmpl` have two layers of escaping (JSON `\"` + shell quoting) that are extremely error-prone. Avoid complex grep/sed patterns; use `jq` (already a dependency) or extract logic into external script files.
+- **`docs/plans/` is gitignored** — `.gitignore` excludes `docs/*` with only `!docs/solutions/` as exception. Plan files created by `ce:plan` are local working documents and cannot be committed. Do not attempt to `git add` files under `docs/plans/` or modify `.gitignore` to include them without explicit user approval.
+
+### テンプレート構文
+
+- **Template escaping** — To output literal `{{ .chezmoi.homeDir }}` in a `.tmpl` file, use `{{ "{{ .chezmoi.homeDir }}" }}`.
+- **`chezmoi execute-template` in CI needs config + source** — `--init --promptString` only answers `promptStringOnce` prompts; it does NOT populate the `.data` namespace (`.ghOrg`, `.profile`) that templates reference. Use a test `chezmoi.toml` with `[data]` section and pass `--config <path> --source "$(pwd)"`. Also exclude `.chezmoi.toml.tmpl` itself since it uses `promptStringOnce` (interactive).
+
+### スクリプト安全性
+
+- **`modify_` scripts: empty stdout = target deletion** — Never use OS guards (`{{ if eq .chezmoi.os "darwin" }}`); on non-matching OS the script outputs nothing and chezmoi zeros the file. Always include `set -e`. Use `printf '%s\n'` (not `printf '%s'`) to preserve trailing newlines stripped by `$(cat)`.
 - **Hook scripts: set one-shot flags after guards, not before** — When using `/tmp` flag files for "run once per session" behavior, place the `touch` **after** context guards (directory exclusions, git checks), not before. If the flag is set before guards, a non-project context (e.g., `$HOME`) consumes the one-shot flag, and navigating to a project later in the same session silently skips the hook.
+
+### 外部制約 & ツール連携
+
+- **Git commit signing** — Requires 1Password SSH agent (`op-ssh-sign`). Commits will fail without it running.
+- **Inline hook commands: keep simple or use jq** — Inline `bash -c` hook commands in `settings.json.tmpl` have two layers of escaping (JSON `\"` + shell quoting) that are extremely error-prone. Avoid complex grep/sed patterns; use `jq` (already a dependency) or extract logic into external script files.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: lint secretlint shellcheck shfmt test-modify check-templates
+.PHONY: lint secretlint shellcheck shfmt test-modify test-scripts check-templates
 
 # File discovery — mirrors .github/workflows/lint.yml and .pre-commit-config.yaml
 SHELL_FILES := $(shell find . -type f \( -name '*.sh' -o -name '*.bash' -o -name 'executable_*' \) \
@@ -10,7 +10,7 @@ TMPL_FILES := $(shell find . -name '*.tmpl' \
 	! -name '.chezmoi.toml.tmpl' 2>/dev/null)
 
 ## Run all checks (mirrors CI)
-lint: secretlint shellcheck shfmt test-modify check-templates
+lint: secretlint shellcheck shfmt test-modify test-scripts check-templates
 
 ## Scan for leaked secrets
 secretlint:
@@ -63,6 +63,44 @@ test-modify:
 		echo "FAIL: missing source file should passthrough stdin"; exit 1; \
 	fi; \
 	echo "PASS: missing source file passes through stdin"
+
+## Smoke test harness-activator script
+test-scripts:
+	@if ! command -v jq >/dev/null 2>&1; then echo "WARNING: jq not found, skipping"; exit 0; fi
+	@echo "Testing harness-activator.sh..."
+	@SCRIPT="$$(pwd)/dot_claude/scripts/executable_harness-activator.sh"; \
+	TEST_SID="test-harness-$$$$-$$(date +%s)"; \
+	cleanup() { rm -f "/tmp/claude-harness-checked-$$TEST_SID"; }; \
+	cleanup; \
+	echo "  Test 1: normal execution inside git repo..."; \
+	output=$$(printf '{"session_id":"%s"}' "$$TEST_SID" | bash "$$SCRIPT" 2>/dev/null); \
+	if echo "$$output" | grep -q "HARNESS EVALUATION REMINDER"; then \
+		echo "  PASS: stdout contains HARNESS EVALUATION REMINDER"; \
+	else \
+		echo "  FAIL: expected HARNESS EVALUATION REMINDER in stdout"; cleanup; exit 1; \
+	fi; \
+	cleanup; \
+	echo "  Test 2: HOME guard suppresses output..."; \
+	TEST_SID2="test-harness-$$$$-$$(date +%s)-home"; \
+	output=$$(cd "$$HOME" && printf '{"session_id":"%s"}' "$$TEST_SID2" | bash "$$SCRIPT" 2>/dev/null); \
+	if [ -z "$$output" ]; then \
+		echo "  PASS: stdout is empty when PWD is HOME"; \
+	else \
+		echo "  FAIL: expected empty stdout when PWD is HOME"; rm -f "/tmp/claude-harness-checked-$$TEST_SID2"; cleanup; exit 1; \
+	fi; \
+	rm -f "/tmp/claude-harness-checked-$$TEST_SID2"; \
+	echo "  Test 3: duplicate session_id produces empty output..."; \
+	TEST_SID3="test-harness-$$$$-$$(date +%s)-dup"; \
+	rm -f "/tmp/claude-harness-checked-$$TEST_SID3"; \
+	printf '{"session_id":"%s"}' "$$TEST_SID3" | bash "$$SCRIPT" > /dev/null 2>&1; \
+	output=$$(printf '{"session_id":"%s"}' "$$TEST_SID3" | bash "$$SCRIPT" 2>/dev/null); \
+	if [ -z "$$output" ]; then \
+		echo "  PASS: second run with same session_id produces empty stdout"; \
+	else \
+		echo "  FAIL: expected empty stdout on duplicate session_id"; rm -f "/tmp/claude-harness-checked-$$TEST_SID3"; cleanup; exit 1; \
+	fi; \
+	rm -f "/tmp/claude-harness-checked-$$TEST_SID3"; \
+	cleanup
 
 ## Validate chezmoi templates
 check-templates:

--- a/docs/solutions/developer-experience/chezmoi-project-harness-rules-and-ci-2026-03-28.md
+++ b/docs/solutions/developer-experience/chezmoi-project-harness-rules-and-ci-2026-03-28.md
@@ -2,7 +2,7 @@
 title: "Project-Specific Harness Rules and CI for chezmoi Dotfiles Repository"
 date: 2026-03-28
 last_updated: 2026-03-29
-updated_reason: "Added mktemp .toml extension pitfall and Makefile single-source-of-truth pattern"
+updated_reason: "Added harness-activator smoke tests, hook guidance rules, Known Pitfalls categorization"
 problem_type: developer_experience
 component: tooling
 symptoms:
@@ -106,6 +106,17 @@ Key details:
 - **CI Enforcement section in `.claude/rules/shell-scripts.md`** — Explicitly states that shell script rules are enforced by CI (`.github/workflows/lint.yml`) and pre-commit (`.pre-commit-config.yaml`), not advisory.
 - **`verify` script in `package.json`** — `pnpm run verify` runs secretlint as a single entry point for validation.
 
+### 6. Harness-activator smoke tests and hook guidance (2026-03-29)
+
+**`test-scripts` Makefile target** — Tests `dot_claude/scripts/executable_harness-activator.sh` with three scenarios: (1) normal execution in a git repo produces "HARNESS EVALUATION REMINDER" output, (2) HOME directory guard suppresses output (exit 0), (3) duplicate session_id produces empty output (flag file prevents re-firing). Includes a `jq` tool guard matching the `shellcheck`/`shfmt` pattern. CI job `harness-scripts` added to `lint.yml`.
+
+**Hook Scripts section in `.claude/rules/shell-scripts.md`** — Promotes three hard-won patterns from `docs/solutions/` into project rules:
+- Exit code contract: `exit 0` for intentional skip, `exit 1` + stderr for errors, never `exit 1` without stderr
+- Session identity: `jq -r '.session_id // empty'` is the stable identifier; `$PPID`/`$$` are unreliable in `bash -c` wrappers
+- One-shot flag pattern: flag file must be set AFTER context guards to prevent non-project contexts from consuming the one-shot
+
+**CLAUDE.md Known Pitfalls categorization** — 14 items reorganized into 4 categories with `###` subheaders (chezmoi CLI & ファイル管理, テンプレート構文, スクリプト安全性, 外部制約 & ツール連携). No content changes — structure only.
+
 ## Why This Works
 
 - **Project rules vs global rules separation** prevents agents from conflating `dot_claude/rules/` (what gets deployed everywhere) with `.claude/rules/` (guidance for working in this specific repo)
@@ -124,6 +135,8 @@ Key details:
 - When adding project rules, include concrete file path references to real repository examples — agents follow patterns better when they can read the actual implementation
 - When creating temp files for tools that infer format from extension (chezmoi, viper-based CLIs), always use `mktemp <dir>/prefix-XXXXXX.ext` with the correct extension — plain `mktemp` produces extensionless files that cause "unknown format" errors
 - When CI and local development run the same checks, consolidate the check logic into a `Makefile` (or equivalent) and have CI call the same targets — this eliminates drift between CI inline commands and local developer invocations
+- **Mirror contract enforcement:** When adding a new `make` target to the `lint` dependency, always add a corresponding CI job in `.github/workflows/lint.yml` — the contract is "if it passes locally, CI will pass too" and the converse must also hold
+- When testing hook scripts in Makefile, pipe JSON to stdin (`printf '{"session_id":"%s"}' "$SID" | bash "$SCRIPT"`), manage `/tmp` flag files for cleanup, and test context guards by running from different directories in subshells
 - Remember that `docs/plans/` is gitignored — don't attempt to commit plan files
 
 ## Related Issues


### PR DESCRIPTION
## Summary

Improve harness health (88→95+) with three targeted changes:

- **Known Pitfalls categorization** — CLAUDE.md's 14 flat-list pitfalls reorganized into 4 category subheaders (chezmoi CLI & file management, template syntax, script safety, external constraints & tooling). Content unchanged.
- **Harness-activator smoke tests** — New `make test-scripts` target testing 3 scenarios (normal output, HOME guard, duplicate prevention) with jq tool guard. CI job `harness-scripts` added to `lint.yml`.
- **Hook guidance promotion** — Exit code contract, session_id pattern, and one-shot flag pattern promoted from `docs/solutions/` to `.claude/rules/shell-scripts.md` as project rules.

Documentation references updated throughout (CLAUDE.md Verification, Common Commands, shell-scripts.md CI Enforcement list).

## Test plan

- [x] `make lint` passes all checks including new `test-scripts`
- [x] `make test-scripts` exercises 3 scenarios with PASS output
- [ ] CI `harness-scripts` job passes on ubuntu-latest