### PR TITLE
fix: allow Renovate and Dependabot in Claude Code Review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -25,6 +25,7 @@ jobs:
         uses: anthropics/claude-code-action@aee99972d0cfa0c47a4563e6fca42d7a5a0cb9bd # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          allowed_bots: 'renovate[bot],dependabot[bot]'
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'


### PR DESCRIPTION
## Summary
- `claude-code-review.yml` の `claude-code-action` に `allowed_bots: 'renovate[bot],dependabot[bot]'` を追加
- Renovate/Dependabot が作成した PR で "non-human actor" エラーが発生していた問題を修正
- セキュリティのため `*` ワイルドカードではなく明示的な bot リストを使用

## Context
- PR #69 (Renovate pin-dependencies) で CI 失敗: `Workflow initiated by non-human actor: renovate (type: Bot). Add bot to allowed_bots list or use '*' to allow all bots.`

## Test plan
- [ ] この PR のマージ後、PR #69 の `claude-code-review` ジョブを re-run して Bot エラーが解消されることを確認

## Post-Deploy Monitoring & Validation
No additional operational monitoring required: CI workflow configuration change only — no runtime impact.

🤖 Generated with Claude Opus 4.6 (1M context) via [Claude Code](https://claude.com/claude-code)