### PR TITLE
refactor: use stdin rate_limits field instead of external API for statusline

### DIFF
--- a/dot_claude/statusline-command.ts
+++ b/dot_claude/statusline-command.ts
@@ -125,7 +125,11 @@ function formatUsageLine(
   bucket: RateLimitBucket | undefined,
   resetLabel: "5h" | "7d",
 ): string {
-  if (bucket && typeof bucket.used_percentage === "number" && typeof bucket.resets_at === "number") {
+  if (
+    bucket &&
+    typeof bucket.used_percentage === "number" &&
+    typeof bucket.resets_at === "number"
+  ) {
     const pct = Math.round(bucket.used_percentage);
     const col = colorForPct(pct);
     const bar = progressBar(pct);
@@ -160,10 +164,7 @@ async function main(): Promise<void> {
     const contextPct = Math.max(0, 100 - remaining);
 
     // Run git commands in parallel
-    const [branch, changes] = await Promise.all([
-      getGitBranch(cwd),
-      getLineChanges(cwd),
-    ]);
+    const [branch, changes] = await Promise.all([getGitBranch(cwd), getLineChanges(cwd)]);
 
     const { added, deleted } = changes;
     const rateLimits = data.rate_limits;


### PR DESCRIPTION
## Summary

Claude Code の最近のアップデートにより、ステータスライン入力の stdin JSON に `rate_limits` フィールドが追加された。これを利用し、外部 API 呼び出しベースのレートリミット取得を stdin 直接読み取りに置き換える。

## Changes

- **外部 API 関連コードの完全削除** (-144行)
  - OAuth トークン取得 (`getOAuthToken` / macOS Keychain アクセス)
  - Anthropic Usage API 呼び出し (`fetchUsage` / `fetch()`)
  - 正キャッシュ (`usage.json`, TTL 6分) / 負キャッシュ (`usage-neg.json`, TTL 30秒)
  - 関連する型定義 (`UsageBucket`, `UsageResponse`, `FetchResult`) と定数
- **stdin `rate_limits` フィールドの利用** (+22行)
  - `RateLimitBucket` 型を追加 (`used_percentage: number`, `resets_at: number`)
  - `StatusLineInput` に `rate_limits` optional フィールドを追加
  - `formatResetTime` を ISO 8601 文字列 → Unix epoch seconds 対応に変更
  - `formatUsageLine` から `authError` パラメータを削除、フィールドの型ガードを追加
- **堅牢性の向上**
  - バケットオブジェクトのフィールド型チェックを追加（空オブジェクト `{}` で NaN 表示を防止）
  - `resets_at` が 0 の場合のガードを追加（1970年表示を防止）

| Before | After |
|--------|-------|
| 外部 API 呼び出し (ネットワーク依存) | stdin から直接取得 (ゼロレイテンシ) |
| OAuth トークン管理 + Keychain アクセス | 不要 |
| 正/負キャッシュファイル管理 | 不要 |
| 319行 | 197行 (-38%) |

## Compatibility

- `rate_limits` フィールドが未提供の場合（古い Claude Code バージョン、非 Pro/Max プラン）、5h/7d ともに N/A 表示にグレースフルデグラデーション
- 表示形式（プログレスバー、色閾値、リセット時刻フォーマット）は既存と同一

## Test plan

- [x] `rate_limits` の `five_hour` と `seven_day` 両方提供時の正常表示
- [x] `rate_limits` 未提供時の N/A 表示
- [x] 部分的提供（`five_hour` のみ）のケース
- [x] 空バケットオブジェクト (`{}`) の NaN フォールバック
- [x] `make lint` パス

---

[![Compound Engineering v2.58.1](https://img.shields.io/badge/Compound_Engineering-v2.58.1-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 4.6 (1M context) via [Claude Code](https://claude.com/claude-code)