### PR TITLE
feat: change Claude Code Review to manual /review comment trigger

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,12 +1,16 @@
 name: Claude Code Review
 
 on:
-  pull_request:
-    types: [opened, synchronize, ready_for_review, reopened]
+  issue_comment:
+    types: [created]
 
 jobs:
   claude-review:
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    if: |
+      github.event_name == 'issue_comment' &&
+      github.event.issue.pull_request &&
+      contains(github.event.comment.body, '/review') &&
+      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -33,4 +37,4 @@ jobs:
             actions: read
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.issue.number }}'


### PR DESCRIPTION
## Summary

- Claude Code Review ワークフローのトリガーを PR 自動イベント（opened, synchronize, ready_for_review, reopened）から、PRコメントによる手動トリガー (`/review`) に変更
- `author_association` ガード（OWNER, MEMBER, COLLABORATOR）により認可されたユーザーのみが起動可能
- `issue_comment` イベントコンテキストに合わせて `github.event.issue.number` を使用するよう修正

## Changes

- `on: pull_request` → `on: issue_comment: types: [created]`
- `if` 条件: PR コンテキスト判定 + `/review` コメント検出 + `author_association` ガード
- `prompt` 内の PR 番号参照: `github.event.pull_request.number` → `github.event.issue.number`

## Usage

PRに対して以下のコメントを投稿することでレビューが起動します:
```
/review
```

## Test plan

- [ ] PRに `/review` コメントを投稿してワークフローが起動することを確認
- [ ] 非認可ユーザー（外部コントリビュータ）のコメントでは起動しないことを確認
- [ ] Issue（PRではない）への `/review` コメントでは起動しないことを確認
- [ ] PR push（synchronize）イベントでは起動しないことを確認

## Note

- `@claude` と `/review` を同時に含むコメントで `claude.yml` と `claude-code-review.yml` の両方が起動する可能性があります（将来的に mutual exclusion guard の追加を検討）
- Fork PR の明示的ガードは削除されましたが、`author_association` ガードが同等の保護を提供します（既存の `claude.yml` と同じ設計）