### PR TITLE
chore: add YAML frontmatter tracking metadata to harness rules

### DIFF
--- a/.claude/rules/chezmoi-patterns.md
+++ b/.claude/rules/chezmoi-patterns.md
@@ -1,3 +1,8 @@
+---
+date: 2026-03-28
+trigger: "Agent uses wrong chezmoi file pattern or mishandles modify_ scripts"
+---
+
 # chezmoi Patterns
 
 Project-specific rules for working in this chezmoi dotfiles repository.

--- a/.claude/rules/renovate-external.md
+++ b/.claude/rules/renovate-external.md
@@ -1,3 +1,8 @@
+---
+date: 2026-03-29
+trigger: "Agent breaks Renovate adjacency contract in .chezmoiexternal.toml"
+---
+
 # Renovate + .chezmoiexternal.toml
 
 Rules for managing external dependencies in `.chezmoiexternal.toml` with Renovate auto-updates.

--- a/.claude/rules/shell-scripts.md
+++ b/.claude/rules/shell-scripts.md
@@ -1,3 +1,8 @@
+---
+date: 2026-03-28
+trigger: "Agent writes shell scripts without proper headers or safety patterns"
+---
+
 # Shell Scripts
 
 Rules for `.chezmoiscripts/` and other shell scripts in this repository.

--- a/dot_claude/rules/common/coding-style.md
+++ b/dot_claude/rules/common/coding-style.md
@@ -1,3 +1,8 @@
+---
+date: 2026-03-06
+trigger: "Agent mutates objects or writes oversized files without proper error handling"
+---
+
 # Coding Style
 
 ## Immutability (CRITICAL)

--- a/dot_claude/rules/common/documentation-language.md
+++ b/dot_claude/rules/common/documentation-language.md
@@ -1,3 +1,8 @@
+---
+date: 2026-03-29
+trigger: "Agent wrote agent-facing documentation or rules in non-English language"
+---
+
 # Documentation Language
 
 ## Agent-Facing Documents Must Be Written in English

--- a/dot_claude/rules/common/git-workflow.md
+++ b/dot_claude/rules/common/git-workflow.md
@@ -1,3 +1,8 @@
+---
+date: 2026-03-06
+trigger: "Agent commits or creates PRs without following conventional commit format"
+---
+
 # Git Workflow
 
 ## Commit Message Format

--- a/dot_claude/rules/common/github-actions.md
+++ b/dot_claude/rules/common/github-actions.md
@@ -1,3 +1,8 @@
+---
+date: 2026-03-29
+trigger: "Agent used invalid in operator or wrong permissions in GitHub Actions workflows"
+---
+
 # GitHub Actions Expressions
 
 ## Critical: `in` operator does not exist

--- a/dot_claude/rules/common/harness-engineering.md
+++ b/dot_claude/rules/common/harness-engineering.md
@@ -1,3 +1,8 @@
+---
+date: 2026-03-28
+trigger: "Agent made a repeatable mistake without creating a preventive rule"
+---
+
 # Harness Engineering
 
 ## Core Principle

--- a/dot_claude/rules/common/security.md
+++ b/dot_claude/rules/common/security.md
@@ -1,3 +1,8 @@
+---
+date: 2026-03-06
+trigger: "Agent commits code without security checks or hardcodes secrets"
+---
+
 # Security Guidelines
 
 ## Mandatory Security Checks

--- a/dot_claude/rules/common/testing.md
+++ b/dot_claude/rules/common/testing.md
@@ -1,3 +1,8 @@
+---
+date: 2026-03-06
+trigger: "Agent writes implementation before tests or skips coverage verification"
+---
+
 # Testing Requirements
 
 ## Minimum Test Coverage: 80%

--- a/dot_claude/rules/golang/coding-style.md
+++ b/dot_claude/rules/golang/coding-style.md
@@ -1,3 +1,8 @@
+---
+date: 2026-03-06
+trigger: "Agent writes Go code without gofmt or proper error wrapping"
+---
+
 # Go Coding Style
 
 > This file extends [common/coding-style.md](../common/coding-style.md) with Go specific content.

--- a/dot_claude/rules/golang/hooks.md
+++ b/dot_claude/rules/golang/hooks.md
@@ -1,3 +1,8 @@
+---
+date: 2026-03-06
+trigger: "Go files not auto-formatted or statically analyzed after edit"
+---
+
 # Go Hooks
 
 > Go specific hooks configuration.

--- a/dot_claude/rules/golang/patterns.md
+++ b/dot_claude/rules/golang/patterns.md
@@ -1,3 +1,8 @@
+---
+date: 2026-03-06
+trigger: "Agent writes Go code without idiomatic patterns like functional options or small interfaces"
+---
+
 # Go Patterns
 
 > This file extends [common/patterns.md](../common/patterns.md) with Go specific content.

--- a/dot_claude/rules/golang/security.md
+++ b/dot_claude/rules/golang/security.md
@@ -1,3 +1,8 @@
+---
+date: 2026-03-06
+trigger: "Agent hardcodes secrets or omits context timeouts in Go code"
+---
+
 # Go Security
 
 > This file extends [common/security.md](../common/security.md) with Go specific content.

--- a/dot_claude/rules/golang/testing.md
+++ b/dot_claude/rules/golang/testing.md
@@ -1,3 +1,8 @@
+---
+date: 2026-03-06
+trigger: "Agent writes Go tests without table-driven patterns or race detection"
+---
+
 # Go Testing
 
 > This file extends [common/testing.md](../common/testing.md) with Go specific content.

--- a/dot_claude/rules/typescript/coding-style.md
+++ b/dot_claude/rules/typescript/coding-style.md
@@ -1,3 +1,8 @@
+---
+date: 2026-03-06
+trigger: "Agent writes TypeScript with mutations or console.log in production code"
+---
+
 # TypeScript/JavaScript Coding Style
 
 > This file extends [common/coding-style.md](../common/coding-style.md) with TypeScript/JavaScript specific content.


### PR DESCRIPTION
Add `date` and `trigger` YAML frontmatter to all 16 harness rule files, enabling the rule lifecycle management workflow (`/harness-rule-lifecycle`) to classify rules as active, stale, or untracked.

Previously, all rule files lacked tracking metadata, making automated staleness detection impossible. Each file now includes its git creation date and a trigger description summarizing when the rule should fire.

**Scope:** 13 global rules (`dot_claude/rules/`), 3 project rules (`.claude/rules/`)

---

[![Compound Engineering v2.40.0](https://img.shields.io/badge/Compound_Engineering-v2.40.0-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 4.6 (1M context, extended thinking) via [Claude Code](https://claude.com/claude-code)