### PR TITLE
feat(gtr-copy): support multi-destination worktree copy

### DIFF
--- a/dot_local/bin/executable_gtr-copy
+++ b/dot_local/bin/executable_gtr-copy
@@ -30,19 +30,21 @@ selected_files=$(
         fzf --multi --header 'Select files to copy (Tab: toggle, Enter: confirm)' --preview 'f={}; bat --color=always -- "$f" 2>/dev/null || cat -- "$f"'
 ) || exit 0
 
-dest_line=$(printf '%s\n' "$destinations" | fzf --header 'Select destination worktree') || exit 0
-dest_worktree=$(printf '%s\n' "$dest_line" | awk '{print $1}')
+selected_destinations=$(printf '%s\n' "$destinations" | fzf --multi --header 'Select destination worktrees (Tab: toggle, Enter: confirm)') || exit 0
 
-copied=0
+while IFS= read -r dest_line; do
+    dest_worktree=$(printf '%s\n' "$dest_line" | awk '{print $1}')
+    copied=0
 
-while IFS= read -r file; do
-    if [[ "$file" == ../* || "$file" == *../* ]]; then
-        echo "gtr-copy: skipping unsafe path: $file" >&2
-        continue
-    fi
-    mkdir -p "${dest_worktree}/$(dirname "$file")"
-    cp "$file" "${dest_worktree}/${file}"
-    copied=$((copied + 1))
-done <<<"$selected_files"
+    while IFS= read -r file; do
+        if [[ "$file" == ../* || "$file" == *../* ]]; then
+            echo "gtr-copy: skipping unsafe path: $file" >&2
+            continue
+        fi
+        mkdir -p "${dest_worktree}/$(dirname "$file")"
+        cp "$file" "${dest_worktree}/${file}"
+        copied=$((copied + 1))
+    done <<<"$selected_files"
 
-echo "gtr-copy: copied ${copied} file(s) to ${dest_worktree}"
+    echo "gtr-copy: copied ${copied} file(s) to ${dest_worktree}"
+done <<<"$selected_destinations"


### PR DESCRIPTION
## Summary

`gtr-copy` の destination worktree 選択を fzf `--multi` に変更し、1回の実行で複数のワークツリーにファイルをコピーできるようにした。

- fzf で複数のコピー先ワークツリーを選択可能（Tab でトグル、Enter で確定）
- 選択したすべてのワークツリーにファイルがコピーされる
- ワークツリーごとにコピー数のサマリーが表示される

## Test plan

- [ ] `make shellcheck && make shfmt` パス済み
- [ ] 単一ワークツリー選択 → 従来通りの動作を確認
- [ ] 複数ワークツリー選択 → 全ワークツリーにファイルがコピーされることを確認
- [ ] fzf で destination 選択をキャンセル → exit 0 で正常終了

---

[![Compound Engineering v2.60.0](https://img.shields.io/badge/Compound_Engineering-v2.60.0-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 4.6 (1M context) via [Claude Code](https://claude.com/claude-code)