### PR TITLE
chore: revert show_full_output debug setting and document classify_inline_comments

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -69,7 +69,9 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }} # zizmor: ignore[secrets-outside-env]
           allowed_bots: 'renovate[bot],dependabot[bot]'
-          show_full_output: true
+          # classify_inline_comments: false bypasses the post-session classification
+          # pipeline which silently drops all code-review plugin comments (see #83, #94).
+          # Revert to default (true) only after upstream fix is confirmed.
           classify_inline_comments: false
           claude_args: '--allowedTools "Bash(gh *),WebFetch"'
           additional_permissions: |


### PR DESCRIPTION
## Summary

- `show_full_output: true` を削除（デフォルト `false` に戻す）— ワークフロー検証完了のためデバッグ出力を無効化
- `classify_inline_comments: false` を維持し、理由コメントを追加 — アップストリームの分類パイプラインが code-review プラグインのコメントを無言で破棄する問題が未修正のため

## Background

PR #83 でデバッグ目的に設定した `show_full_output: true` と `classify_inline_comments: false` のうち、検証完了に伴い `show_full_output` のみデフォルトに戻す。

### Input の役割

| Input | Default | 役割 | 判断 |
|-------|---------|------|------|
| `show_full_output` | `false` | Claude Code の全 JSON 出力をログに表示（セキュリティリスクあり） | `false` に戻す — デバッグ不要 |
| `classify_inline_comments` | `true` | インラインコメントを分類パイプラインでフィルタリング | `false` を維持 — パイプラインが全コメントを破棄する問題が未修正 |

## Test plan

- [x] `make actionlint` passes
- [x] All pre-commit hooks pass (secretlint, shellcheck, shfmt, oxlint, oxfmt, actionlint, zizmor)
- [ ] Next `@claude /review` on a non-trivial PR posts comments correctly

## Post-Deploy Monitoring & Validation

- 次回 `@claude /review` 実行時にレビューコメントが正常に投稿されることを確認
- コメントが投稿されない場合は `classify_inline_comments: false` が維持されていることを再確認

Closes #94

🤖 Generated with [Claude Code](https://claude.ai/code)