### PR TITLE
chore: snapshot 8 ECC instincts for auto-promote CI

### DIFF
--- a/docs/plans/2026-04-05-002-chore-snapshot-instincts-pr-plan.md
+++ b/docs/plans/2026-04-05-002-chore-snapshot-instincts-pr-plan.md
@@ -1,0 +1,55 @@
+---
+title: "chore: Snapshot instincts and create PR"
+type: chore
+status: active
+date: 2026-04-05
+---
+
+# chore: Snapshot instincts and create PR
+
+## Overview
+
+Run `scripts/snapshot-instincts.sh` to refresh the instinct snapshot in `dot_claude/instinct-snapshots/`, then create a PR with the updated snapshot. This keeps the CI auto-promote workflow supplied with fresh instinct data.
+
+## Problem Frame
+
+The instinct snapshot in the source tree is stale (3 instincts), while the live directory has 8 instincts including 5 newly created ones. The auto-promote CI workflow reads from the snapshot, not the live directory, so it needs refreshing.
+
+## Scope Boundaries
+
+- Only snapshot refresh and PR creation — no code changes
+- No observer bug fixes in this PR
+
+## Implementation Units
+
+- [ ] **Unit 1: Run snapshot script**
+
+**Goal:** Refresh `dot_claude/instinct-snapshots/` with all 8 current instincts
+
+**Files:**
+- Modify: `dot_claude/instinct-snapshots/*.md` (8 instinct files)
+- Modify: `dot_claude/instinct-snapshots/metadata.json`
+
+**Approach:**
+- Run `scripts/snapshot-instincts.sh` from repo root
+- Verify output shows 8 instincts copied
+
+**Test expectation:** none — operational script execution
+
+**Verification:**
+- Script reports 8 instincts copied, 0 skipped
+- `dot_claude/instinct-snapshots/metadata.json` timestamp is current
+
+- [ ] **Unit 2: Create branch, commit, and PR**
+
+**Goal:** Land the snapshot update via PR (main branch is protected)
+
+**Approach:**
+- Create feature branch `chore/snapshot-instincts-2026-04-05`
+- Commit all snapshot files
+- Open PR targeting main
+
+**Test expectation:** none — git operations only
+
+**Verification:**
+- PR is created and CI passes

--- a/dot_claude/instinct-snapshots/chezmoi-source-not-target.md
+++ b/dot_claude/instinct-snapshots/chezmoi-source-not-target.md
@@ -1,0 +1,21 @@
+---
+id: chezmoi-source-not-target
+trigger: when editing chezmoi-managed configuration files
+confidence: 0.7
+domain: file-patterns
+source: session-observation
+scope: project
+project_id: 23e6ae2f0a00
+project_name: chezmoi
+---
+
+# Edit Source Files, Not Deployed Targets
+
+## Action
+Always edit files under `~/.local/share/chezmoi/` (the source directory), never the deployed targets under `~/`. Changes to deployed targets are overwritten on next `chezmoi apply` and are not version-controlled. Use `chezmoi source-path <target>` to find the source file.
+
+## Evidence
+- Observed 5+ times in session 4937b2e4 (2026-04-05)
+- Pattern: All edits consistently target dot_claude/settings.json.tmpl, not ~/.claude/settings.json; scripts/ not deployed paths
+- Observer-loop.sh is an exception — it lives in plugin directory, not chezmoi source
+- Last observed: 2026-04-05

--- a/dot_claude/instinct-snapshots/github-actions-actionlint-validation.md
+++ b/dot_claude/instinct-snapshots/github-actions-actionlint-validation.md
@@ -1,0 +1,21 @@
+---
+id: github-actions-actionlint-validation
+trigger: when creating or modifying GitHub Actions workflow files (.github/workflows/*.yml)
+confidence: 0.7
+domain: workflow
+source: session-observation
+scope: project
+project_id: 23e6ae2f0a00
+project_name: chezmoi
+---
+
+# GitHub Actions Workflow Validation with actionlint
+
+## Action
+Run `actionlint <workflow-file>` immediately after editing any GitHub Actions workflow file to catch syntax errors, type mismatches, and expression issues before committing.
+
+## Evidence
+- Observed 8+ times in session 4937b2e4 (2026-04-05)
+- Pattern: Edit auto-promote.yml → actionlint → fix errors → repeat cycle
+- Common catches: invalid expression syntax, missing permissions, incorrect `contains(fromJSON(...))` usage
+- Last observed: 2026-04-05

--- a/dot_claude/instinct-snapshots/instinct-snapshot-before-push.md
+++ b/dot_claude/instinct-snapshots/instinct-snapshot-before-push.md
@@ -1,0 +1,21 @@
+---
+id: instinct-snapshot-before-push
+trigger: when preparing to push changes that involve the auto-promote CI workflow
+confidence: 0.7
+domain: workflow
+source: session-observation
+scope: project
+project_id: 23e6ae2f0a00
+project_name: chezmoi
+---
+
+# Snapshot Instincts Before Push for CI
+
+## Action
+Run `scripts/snapshot-instincts.sh` before pushing to ensure the auto-promote CI workflow has fresh instinct data to process. The snapshot copies instinct files from `~/.claude/homunculus/` to `dot_claude/instinct-snapshots/` in the source tree. CI validates snapshot freshness (14-day max age).
+
+## Evidence
+- Observed 3+ times in session 4937b2e4 (2026-04-05)
+- Pattern: Snapshot script developed and tested as part of auto-promote workflow
+- validate-instinct-snapshot.sh enforces freshness, count (>= 5), and format
+- Last observed: 2026-04-05

--- a/dot_claude/instinct-snapshots/json-validation-with-jq.md
+++ b/dot_claude/instinct-snapshots/json-validation-with-jq.md
@@ -1,0 +1,21 @@
+---
+id: json-validation-with-jq
+trigger: when validating or extracting fields from JSON-formatted observations and event logs
+confidence: 0.7
+domain: workflow
+source: session-observation
+scope: project
+project_id: 23e6ae2f0a00
+project_name: chezmoi
+---
+
+# JSON Validation and Extraction with jq
+
+## Action
+Use `jq` to validate observation structure and extract fields instead of shell string manipulation.
+
+## Evidence
+- Observed 3+ times in session 6e0cc6bc-f31a-498c-b915-9db7e712e48c
+- Pattern: Commands like `head -1 observations.jsonl | jq -r '.tool_name // .event_type // "unknown"'` and `jq 'keys'` for schema inspection
+- Used to validate observation format before analysis
+- Last observed: 2026-04-04T14:34:43Z

--- a/dot_claude/instinct-snapshots/make-lint-after-edits.md
+++ b/dot_claude/instinct-snapshots/make-lint-after-edits.md
@@ -1,0 +1,21 @@
+---
+id: make-lint-after-edits
+trigger: when completing edits to shell scripts, workflows, or Makefile in the chezmoi source tree
+confidence: 0.7
+domain: workflow
+source: session-observation
+scope: project
+project_id: 23e6ae2f0a00
+project_name: chezmoi
+---
+
+# Run make lint After Source Tree Edits
+
+## Action
+Run `make lint` after editing shell scripts, GitHub Actions workflows, Makefile, or template files to catch issues before committing. This mirrors the CI pipeline and catches shellcheck, shfmt, actionlint, oxlint, secretlint, and template validation errors.
+
+## Evidence
+- Observed 4+ times in session 4937b2e4 (2026-04-05)
+- Pattern: Edit script/workflow → make lint → fix reported errors → repeat until clean
+- CI and local use identical Makefile targets — passing locally guarantees CI pass
+- Last observed: 2026-04-05

--- a/dot_claude/instinct-snapshots/metadata.json
+++ b/dot_claude/instinct-snapshots/metadata.json
@@ -1,0 +1,6 @@
+{
+  "timestamp": "2026-04-05T03:22:40Z",
+  "project_id": "23e6ae2f0a00",
+  "project_name": "chezmoi",
+  "instinct_count": 8
+}

--- a/dot_claude/instinct-snapshots/observer-diagnostic-restart.md
+++ b/dot_claude/instinct-snapshots/observer-diagnostic-restart.md
@@ -1,0 +1,21 @@
+---
+id: observer-diagnostic-restart
+trigger: when observer process appears stalled or analysis hangs
+confidence: 0.7
+domain: debugging
+source: session-observation
+scope: project
+project_id: 23e6ae2f0a00
+project_name: chezmoi
+---
+
+# Observer Process Diagnostic and Restart Cycle
+
+## Action
+When observer analysis reaches max-turns or hangs, kill the process and restart with `--reset`, then run analysis manually with `tail -n` observations to debug.
+
+## Evidence
+- Observed 4 times in session 6e0cc6bc-f31a-498c-b915-9db7e712e48c
+- Pattern: Kill PID, remove `.observer.pid` and `.observer.lock` files, sleep 1s, restart with `--reset` flag
+- Followed by manual invocation of `tail -n` on observations to isolate the analysis
+- Last observed: 2026-04-04T14:33:07Z

--- a/dot_claude/instinct-snapshots/pr-workflow-for-all-changes.md
+++ b/dot_claude/instinct-snapshots/pr-workflow-for-all-changes.md
@@ -1,0 +1,22 @@
+---
+id: pr-workflow-for-all-changes
+trigger: when pushing changes to the repository, including automated CI workflows
+confidence: 0.85
+domain: git
+source: session-observation
+scope: project
+project_id: 23e6ae2f0a00
+project_name: chezmoi
+---
+
+# All Changes Must Go Through PR Workflow
+
+## Action
+Never push directly to main branch. Always create a feature branch and open a PR, even for automated changes from CI workflows (auto-promote, harness-remediate). Main branch has protection rules requiring PR review.
+
+## Evidence
+- Observed 4+ times in session 4937b2e4 (2026-04-05)
+- Pattern: auto-promote workflow initially designed to push directly to main, had to be redesigned to create PRs instead
+- User explicitly stated: main branch には直接 push することを禁止する ruleset を設定している
+- Solution documented in docs/solutions/integration-issues/ci-workflow-branch-protection-requires-pr-flow-2026-04-05.md
+- Last observed: 2026-04-05

--- a/dot_claude/instinct-snapshots/temporary-analysis-file-pattern.md
+++ b/dot_claude/instinct-snapshots/temporary-analysis-file-pattern.md
@@ -1,0 +1,21 @@
+---
+id: temporary-analysis-file-pattern
+trigger: when preparing observations for analysis or debugging observer output
+confidence: 0.7
+domain: file-patterns
+source: session-observation
+scope: project
+project_id: 23e6ae2f0a00
+project_name: chezmoi
+---
+
+# Temporary Analysis File Pattern
+
+## Action
+Create `.observer-tmp/ecc-observer-analysis.XXXXXX.jsonl` using `mktemp` and populate with `tail -n` observations before invoking analysis.
+
+## Evidence
+- Observed 3 times in session 6e0cc6bc-f31a-498c-b915-9db7e712e48c
+- Pattern: `mkdir -p .observer-tmp`, `mktemp .observer-tmp/ecc-observer-analysis.XXXXXX.jsonl`, then `tail -n 500 observations.jsonl > analysis_file`
+- Stores analysis data separately from live observations; cleanup with `rm -f` after analysis
+- Last observed: 2026-04-04T14:33:32Z


### PR DESCRIPTION
## Summary

- Refresh instinct snapshots from 3 → 8 instincts after manual creation (observer was failing due to max-turns limit)
- 5 new instincts: actionlint validation, PR workflow enforcement, make lint workflow, chezmoi source-not-target, instinct snapshot before push
- Includes plan document for traceability

## Context

ECC observer was repeatedly hitting `max-turns (10)` limit, preventing automatic instinct creation. Instincts were created manually based on observation archive analysis. The snapshot enables the auto-promote CI workflow to process these instincts.

## Test plan

- [x] `scripts/snapshot-instincts.sh` reports 8 instincts, 0 skipped
- [x] `metadata.json` has correct timestamp and count
- [x] All instinct files have valid frontmatter (id, trigger, confidence, domain)
- [x] Pre-commit hooks pass (secretlint, oxfmt, scan-sensitive)