### PR TITLE
fix: skip non-existent paths in safehouse sandbox config

### DIFF
--- a/dot_config/zsh/sandbox.zsh
+++ b/dot_config/zsh/sandbox.zsh
@@ -14,9 +14,15 @@ claude() {
 _claude_safehouse() {
   local -a args=()
   local config="${XDG_CONFIG_HOME:-$HOME/.config}/safehouse/config"
+  local dir_path
   if [[ -f "$config" ]]; then
     while IFS= read -r line || [[ -n "$line" ]]; do
       [[ -z "$line" || "$line" == \#* ]] && continue
+      # Skip --add-dirs / --add-dirs-ro entries whose path does not exist
+      if [[ "$line" == --add-dirs=* || "$line" == --add-dirs-ro=* ]]; then
+        dir_path="${line#*=}"
+        [[ ! -e "$dir_path" ]] && continue
+      fi
       args+=("$line")
     done < "$config"
   fi


### PR DESCRIPTION
safehouse validates that all `--add-dirs` / `--add-dirs-ro` paths exist before launching the sandboxed process, failing immediately if any are missing. Optional dev tool directories like `~/.bun` or `~/.pnpm-state` may not exist on every machine, causing `claude` to fail at startup with "Path does not exist" errors.

The sandbox wrapper now filters out non-existent paths at runtime before passing them to safehouse, so the config can list optional directories without breaking startup.

---

[![Compound Engineering v2.62.0](https://img.shields.io/badge/Compound_Engineering-v2.62.0-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 4.6 (1M context, extended thinking) via [Claude Code](https://claude.com/claude-code)