### PR TITLE
docs: add marketplace sync brainstorm and implementation plan

### DIFF
--- a/docs/brainstorms/2026-03-08-marketplace-sync-brainstorm.md
+++ b/docs/brainstorms/2026-03-08-marketplace-sync-brainstorm.md
@@ -1,7 +1,7 @@
 # Brainstorm: Declarative Marketplace Sync via chezmoi
 
 **Date:** 2026-03-08
-**Status:** Ready for planning
+**Status:** Completed
 
 ## What We're Building
 
@@ -62,7 +62,7 @@ The new approach is **unidirectional and declarative**: the source list is the s
 - `.chezmoiignore` — add `known_marketplaces.json` and `installed_plugins.json`
 - `CLAUDE.md` — update architecture documentation
 
-### Marketplace list content
+### Marketplace list content (as of 2026-03-08)
 
 ```
 anthropics/skills
@@ -72,6 +72,8 @@ OthmanAdi/planning-with-files
 affaan-m/everything-claude-code
 EveryInc/compound-engineering-plugin
 ```
+
+> Note: The current list in `dot_claude/plugins/marketplaces.txt` may include additional entries added after this brainstorm.
 
 ## Open Questions
 

--- a/docs/plans/2026-03-08-refactor-declarative-marketplace-sync-plan.md
+++ b/docs/plans/2026-03-08-refactor-declarative-marketplace-sync-plan.md
@@ -32,11 +32,11 @@ A unidirectional, declarative approach (see brainstorm: `docs/brainstorms/2026-0
 - **Remove** all `modify_`, `.data`, and reverse-sync files for both `known_marketplaces.json` and `installed_plugins.json`
 - **Add** `installed_plugins.json` and `known_marketplaces.json` to `.chezmoiignore`
 
-Key insight: `*.txt` is already in `.chezmoiignore`, so `marketplaces.txt` won't deploy to `~/` but is readable via `{{ include }}` for hash tracking. `claude plugin marketplace add` is idempotent — adding an already-registered marketplace is a no-op.
+Key insight: `dot_claude/plugins/marketplaces.txt` is ignored via an explicit `.claude/plugins/marketplaces.txt` entry in `.chezmoiignore` (note: root-level `*.txt` does not match nested paths), so it won't deploy to `~/` but is readable via `{{ include }}` for hash tracking. `claude plugin marketplace add` is idempotent — adding an already-registered marketplace is a no-op.
 
 ## Acceptance Criteria
 
-- [x] `marketplaces.txt` lists all 6 marketplaces (deduplicated — GitHub form only for EveryInc)
+- [x] `marketplaces.txt` lists all marketplaces at time of implementation (deduplicated — GitHub form only for EveryInc)
 - [x] `scripts/update-marketplaces.sh` generates `marketplaces.txt` from current CLI state
 - [x] `run_onchange_` script adds marketplaces when list changes
 - [x] `chezmoi apply` on a fresh machine registers all listed marketplaces
@@ -126,7 +126,7 @@ done < "{{ .chezmoi.sourceDir }}/dot_claude/plugins/marketplaces.txt"
 | `.chezmoiscripts/run_after_10-ensure-marketplaces.sh.tmpl` | Delete (replaced by `run_onchange_`) |
 | `.chezmoiscripts/run_after_20-sync-plugins.sh.tmpl` | Delete (reverse sync no longer needed) |
 
-### Phase 3: Update `.chezmoiignore`
+### Phase 3: Update `.chezmoiignore` *(already applied)*
 
 Add to the `.claude/plugins/` section (after line 37):
 


### PR DESCRIPTION
Adds design documentation for the declarative marketplace sync refactor (completed in earlier PRs). These docs capture the brainstorm rationale and phased implementation plan for replacing the 3-layer bidirectional sync (`modify_` + `.data` + `run_after_`) with a plain-text list approach.

- `docs/brainstorms/2026-03-08-marketplace-sync-brainstorm.md` — key decisions, alternatives considered, and why unidirectional sync was chosen
- `docs/plans/2026-03-08-refactor-declarative-marketplace-sync-plan.md` — phased plan with acceptance criteria (all marked complete)

---

[![Compound Engineering v2.62.0](https://img.shields.io/badge/Compound_Engineering-v2.62.0-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 4.6 (1M context, extended thinking) via [Claude Code](https://claude.com/claude-code)