### PR TITLE
fix: add allowed_bots to harness-auto-remediate workflow

### DIFF
--- a/.github/workflows/harness-auto-remediate.yml
+++ b/.github/workflows/harness-auto-remediate.yml
@@ -68,6 +68,7 @@ jobs:
         uses: anthropics/claude-code-action@58dbe8ed6879f0d3b02ac295b20d5fdfe7733e0c # v1.0.85
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }} # zizmor: ignore[secrets-outside-env]
+          allowed_bots: 'claude[bot]'
           prompt: |
             You are a harness engineering remediation agent. A harness-analysis issue has been filed and you need to propose and validate a fix.
 

--- a/docs/plans/2026-04-05-006-fix-harness-auto-remediate-allowed-bots-plan.md
+++ b/docs/plans/2026-04-05-006-fix-harness-auto-remediate-allowed-bots-plan.md
@@ -1,0 +1,34 @@
+---
+title: "fix: Add allowed_bots to harness-auto-remediate workflow"
+type: fix
+status: completed
+date: 2026-04-05
+---
+
+# fix: Add allowed_bots to harness-auto-remediate workflow
+
+## Overview
+
+The `harness-auto-remediate.yml` workflow fails because `claude-code-action` v1.0.85 rejects bot-initiated triggers unless `allowed_bots` is explicitly set.
+
+## Problem Frame
+
+The workflow's `if` condition correctly allows `claude[bot]` (fixed in 2026-03-30), so the job now runs instead of being skipped. However, `claude-code-action` itself has an internal actor validation that rejects non-human actors unless listed in `allowed_bots`.
+
+Error: `Workflow initiated by non-human actor: claude (type: Bot). Add bot to allowed_bots list or use '*' to allow all bots.`
+
+Three consecutive failures on 2026-04-05 confirm this.
+
+## Requirements Trace
+
+- R1. `claude-code-action` must execute when triggered by `claude[bot]` via `harness-analysis` label
+- R2. Security: only `claude[bot]` should be allowed, not all bots
+- R3. No changes to remediation logic or other workflows
+
+## Implementation
+
+Single change: add `allowed_bots: 'claude[bot]'` to the `claude-code-action` step's `with` inputs.
+
+**File:** `.github/workflows/harness-auto-remediate.yml` (line ~69)
+
+**Verification:** `make lint` (includes actionlint + zizmor)


### PR DESCRIPTION
`claude-code-action` v1.0.85 rejects bot-initiated workflow triggers unless `allowed_bots` is explicitly configured. The harness-analysis → auto-remediate pipeline was broken because `claude[bot]` (which applies the `harness-analysis` label) was rejected at the action level, despite the workflow `if` condition already allowing it.

Adds `allowed_bots: 'claude[bot]'` to the `claude-code-action` step so the remediation agent can execute when triggered by harness-analysis issues.

---

[![Compound Engineering v2.62.0](https://img.shields.io/badge/Compound_Engineering-v2.62.0-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 4.6 (1M context, extended thinking) via [Claude Code](https://claude.com/claude-code)