### PR TITLE
docs: improve CLAUDE.md quality and compliance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,6 +127,9 @@ make actionlint                # Lint GitHub Actions workflows (syntax + types)
 make zizmor                    # Security audit GitHub Actions workflows
 make test-modify               # Smoke test modify_ scripts
 make test-scripts              # Smoke test harness scripts
+make test-pipeline-health      # Smoke test pipeline-health.sh
+make test-snapshot-instincts   # Smoke test snapshot-instincts.sh
+make test-validate-snapshot    # Smoke test validate-instinct-snapshot.sh
 make check-templates           # Validate chezmoi .tmpl files
 make scan-sensitive            # Scan all .md files for PII and sensitive info
 make test-sensitive            # Smoke test sensitive info scanner

--- a/dot_claude/CLAUDE.md
+++ b/dot_claude/CLAUDE.md
@@ -1,13 +1,12 @@
-# 多角的視点に基づく意志決定
+# Multi-Perspective Decision Making
 
-- ユーザーの意見も偏った視点からの一意見に過ぎないことを理解し、他の視点や情報源を考慮する
-- ユーザーに迎合せず、必要に応じて反論や提案を行う
+- Treat user opinions as one perspective among many — consider other viewpoints and sources
+- Push back and suggest alternatives when warranted, rather than defaulting to agreement
 
-# ルール構成
+# Rule Structure
 
-詳細なコーディングルール・テストポリシー・セキュリティガイドラインは `~/.claude/rules/` に分散配置されている。言語別（`golang/`, `typescript/`）および共通（`common/`）のサブディレクトリで構成。このファイルにはプロジェクト横断の行動指針のみを記載する。
+Detailed coding rules, test policies, and security guidelines live in `~/.claude/rules/`, organized by language (`golang/`, `typescript/`) and shared (`common/`). This file contains only cross-project behavioral guidelines.
 
-# Compound Engineering Plugin に関する補足
+# Compound Engineering Plugin Notes
 
-`ralph-wiggum` skill は `ralph-loop` という名称で存在する場合がある。
-`/ralph-loop:ralph-loop` によって起動できる。
+The `ralph-wiggum` skill may appear as `ralph-loop`. Launch via `/ralph-loop:ralph-loop`.


### PR DESCRIPTION
## Summary

- Add 3 missing Makefile test targets (`test-pipeline-health`, `test-snapshot-instincts`, `test-validate-snapshot`) to the project CLAUDE.md Verification section — these are part of `make lint` but were undocumented
- Translate global CLAUDE.md (`dot_claude/CLAUDE.md`) from Japanese to English to comply with the `documentation-language.md` rule requiring agent-facing documents be written in English

## Test plan

- [ ] `make lint` passes (verified locally)
- [ ] `chezmoi diff` shows expected changes to `~/.claude/CLAUDE.md`

---

[![Compound Engineering v2.62.0](https://img.shields.io/badge/Compound_Engineering-v2.62.0-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 4.6 (1M context, extended thinking) via [Claude Code](https://claude.com/claude-code)