### PR TITLE
chore: add ecc-observer-diagnosis skill to chezmoi management

### DIFF
--- a/docs/plans/2026-04-05-008-chore-manage-unmanaged-skills-plan.md
+++ b/docs/plans/2026-04-05-008-chore-manage-unmanaged-skills-plan.md
@@ -1,0 +1,112 @@
+---
+title: "chore: Bring unmanaged Claude Code skills under chezmoi management"
+type: chore
+status: completed
+date: 2026-04-05
+---
+
+# chore: Bring unmanaged Claude Code skills under chezmoi management
+
+## Overview
+
+The `ecc-observer-diagnosis` skill exists only at `~/.claude/skills/ecc-observer-diagnosis/SKILL.md` — it is deployed but not tracked by chezmoi. This means it will be lost on a new machine and is not version-controlled. Add it to the chezmoi source tree so it deploys consistently.
+
+## Problem Frame
+
+Skills in `~/.claude/skills/` come from four sources:
+
+| Source | Example | Managed? |
+|--------|---------|----------|
+| Source tree (`dot_claude/skills/`) | `propose-harness-improvement`, `execplan`, etc. | Yes |
+| `.chezmoiexternal.toml` | `claudeception` | Yes (SHA-pinned) |
+| Plugin symlinks (`.agents/skills/`) | `find-skills`, `gemini-api-dev`, etc. | No (excluded in `.chezmoiignore`) |
+| Runtime learned | `learned/` | No (excluded in `.chezmoiignore`) |
+
+`ecc-observer-diagnosis` doesn't fit any managed category — it was created manually and currently sits untracked in the deploy target.
+
+## Requirements Trace
+
+- R1. `ecc-observer-diagnosis` skill must deploy to `~/.claude/skills/ecc-observer-diagnosis/SKILL.md` via `chezmoi apply`
+- R2. The skill content must be version-controlled in the source tree
+- R3. No existing managed skills or ignore patterns should be disrupted
+
+## Scope Boundaries
+
+- Only `ecc-observer-diagnosis` is in scope — it is the only unmanaged skill
+- Plugin-provided symlink skills (`find-skills`, `gemini-api-dev`, `parallel-task`, `swarm-planner`) and `learned/` are intentionally unmanaged and should stay excluded
+- No new declarative sync patterns needed — this is a simple source-tree addition
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- Existing managed skills follow the pattern: `dot_claude/skills/<name>/SKILL.md` in source tree → deploys to `~/.claude/skills/<name>/SKILL.md`
+- Five skills already use this pattern: `compound-harness-knowledge`, `execplan`, `node-typescript-mts-esm`, `propose-harness-improvement`, `validate-harness-proposal`
+- `.chezmoiignore` excludes specific skill directories by name (symlinks, learned), not by glob — so new directories under `dot_claude/skills/` deploy automatically
+
+### Institutional Learnings
+
+- `docs/solutions/integration-issues/chezmoi-scripts-deployment-gap-repo-only-vs-deployed-2026-04-04.md` — scripts/files that are needed at runtime must be in `dot_*` paths, not `scripts/`
+- Never edit deployed targets directly — always edit the chezmoi source file
+
+## Key Technical Decisions
+
+- **Direct source tree addition (not `.chezmoiexternal.toml`)**: The skill is locally authored (not an external repo), so it belongs in `dot_claude/skills/` like the other five local skills
+- **No `.chezmoiignore` changes needed**: New directories under `dot_claude/skills/` deploy automatically — no ignore pattern blocks them
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Should the skill be a template?** No — the skill content contains no template variables (`.chezmoi.homeDir`, `.profile`, etc.). Regular file is correct.
+
+### Deferred to Implementation
+
+- None — this is straightforward file addition.
+
+## Implementation Units
+
+- [x] **Unit 1: Add ecc-observer-diagnosis to chezmoi source tree**
+
+**Goal:** Track the skill in version control and enable consistent deployment via `chezmoi apply`.
+
+**Requirements:** R1, R2, R3
+
+**Dependencies:** None
+
+**Files:**
+- Create: `dot_claude/skills/ecc-observer-diagnosis/SKILL.md`
+
+**Approach:**
+- Copy the content from the deployed `~/.claude/skills/ecc-observer-diagnosis/SKILL.md` into the source tree at `dot_claude/skills/ecc-observer-diagnosis/SKILL.md`
+- Verify `chezmoi managed` shows the new file
+- Verify `chezmoi diff` shows no drift (source matches deployed target)
+
+**Patterns to follow:**
+- `dot_claude/skills/propose-harness-improvement/SKILL.md` — same structure (directory + single SKILL.md)
+
+**Test scenarios:**
+- Happy path: `chezmoi managed | grep ecc-observer-diagnosis` returns the skill path
+- Happy path: `chezmoi diff` shows no diff for the skill (source matches target)
+- Edge case: `chezmoi apply --dry-run` does not attempt to overwrite or delete any other skills
+
+**Verification:**
+- `chezmoi managed` includes `.claude/skills/ecc-observer-diagnosis/SKILL.md`
+- `chezmoi diff` shows no changes for the skill file
+- Existing skills remain unaffected
+
+## System-Wide Impact
+
+- **Interaction graph:** None — adding a file to the source tree has no side effects
+- **Unchanged invariants:** All existing skills, `.chezmoiignore` patterns, and `.chezmoiexternal.toml` entries remain unchanged
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Content drift between deployed and source | Verify with `chezmoi diff` immediately after adding |
+
+## Sources & References
+
+- Related memory: `ecc_observer_fix.md` — context on why this skill was created
+- Related code: `dot_claude/skills/` — existing local skill pattern

--- a/dot_claude/skills/ecc-observer-diagnosis/SKILL.md
+++ b/dot_claude/skills/ecc-observer-diagnosis/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: ecc-observer-diagnosis
+description: |
+  Diagnose and fix ECC continuous learning observer failures preventing instinct 
+  creation. Use when: (1) pipeline-health.sh reports "Observer Analysis: BROKEN",
+  (2) observations.jsonl grows but instinct count remains 0, (3) observer.log shows
+  "cat: .observer-tmp/ecc-observer-prompt.XXX: No such file or directory" or
+  "Error: Input must be provided either through stdin or as a prompt argument when
+  using --print". Covers temp file race condition fix, --dangerously-skip-permissions
+  fix, manual instinct generation, and session-guardian active hours constraint.
+author: Claude Code
+version: 1.0.0
+date: 2026-04-05
+---
+
+# ECC Observer Diagnosis and Repair
+
+## Problem
+
+The ECC continuous learning observer (`observer-loop.sh`) fails to create instincts from
+observations. The pipeline silently degrades: observations accumulate but the Haiku
+analysis step fails, producing zero instincts indefinitely.
+
+## Context / Trigger Conditions
+
+- `pipeline-health.sh` reports `Observer Analysis: BROKEN` and `Instinct Creation: BROKEN (0 instincts)`
+- `observer.log` shows repeated errors:
+  ```
+  cat: .observer-tmp/ecc-observer-prompt.XXXXXX: No such file or directory
+  Error: Input must be provided either through stdin or as a prompt argument when using --print
+  Claude analysis failed (exit 1)
+  ```
+- Observations count keeps growing (observations.jsonl) but no instinct files appear
+- OR: Haiku analysis runs but never creates instinct files (reaches max turns without writing)
+
+## Solution
+
+### Bug 1: Temp File Race Condition
+
+**File:** `~/.claude/plugins/marketplaces/everything-claude-code/skills/continuous-learning-v2/agents/observer-loop.sh`
+
+The script creates a temp file with `mktemp`, writes the prompt via heredoc, then reads it
+back with `$(cat "$prompt_file")`. This intermittently fails (file not found despite mktemp
+succeeding). Root cause is unclear but reproducible.
+
+**Fix:** Replace temp file with shell variable assignment.
+
+```bash
+# BEFORE (broken):
+prompt_file="$(mktemp "${observer_tmp_dir}/ecc-observer-prompt.XXXXXX")"
+cat > "$prompt_file" <<PROMPT
+...prompt content...
+PROMPT
+claude ... -p "$(cat "$prompt_file")" >> "$LOG_FILE" 2>&1 &
+rm -f "$prompt_file"
+
+# AFTER (fixed):
+prompt_content="...prompt content..."
+claude ... -p "$prompt_content" < /dev/null >> "$LOG_FILE" 2>&1 &
+```
+
+### Bug 2: Missing --dangerously-skip-permissions
+
+The `claude --model haiku --print` invocation lacks `--dangerously-skip-permissions`. 
+Without it, the Write tool is blocked by Claude Code's internal permission system even
+in `--print` mode. Haiku detects patterns but cannot create instinct files.
+
+**Fix:** Add `--dangerously-skip-permissions` and `< /dev/null` to the claude command.
+
+```bash
+ECC_SKIP_OBSERVE=1 ECC_HOOK_PROFILE=minimal claude --model haiku --max-turns "$max_turns" --print \
+  --dangerously-skip-permissions \
+  --allowedTools "Read,Write" \
+  -p "$prompt_content" < /dev/null >> "$LOG_FILE" 2>&1 &
+```
+
+### Manual Instinct Generation (for testing)
+
+When the observer is broken, generate instincts manually:
+
+```bash
+cd ~/.claude/homunculus/projects/<hash>
+mkdir -p .observer-tmp instincts/personal
+
+analysis_file=".observer-tmp/manual-analysis.jsonl"
+tail -n 30 observations.jsonl > "$analysis_file"
+
+ECC_SKIP_OBSERVE=1 ECC_HOOK_PROFILE=minimal command claude --model haiku --max-turns 15 --print \
+  --dangerously-skip-permissions \
+  --allowedTools "Read,Write" \
+  -p "Read .observer-tmp/manual-analysis.jsonl and identify patterns. Write instinct files to $(pwd)/instincts/personal/<id>.md." \
+  < /dev/null 2>&1
+```
+
+### Session-Guardian Active Hours
+
+The observer only analyzes during active hours (default: 8:00-23:00). Outside this window,
+`observer.log` shows `session-guardian: outside active hours`. This is expected behavior,
+not a bug.
+
+## Verification
+
+```bash
+# Check pipeline health
+~/.claude/scripts/pipeline-health.sh
+
+# Check observer log for recent success
+tail -20 ~/.claude/homunculus/projects/<hash>/observer.log
+
+# Check instinct files were created
+ls ~/.claude/homunculus/projects/<hash>/instincts/personal/
+```
+
+## Notes
+
+- **Plugin updates overwrite patches.** The observer-loop.sh is part of the 
+  `everything-claude-code` plugin. Updates via `claude plugin marketplace` will 
+  restore the original broken code. Re-apply patches after updates.
+- **Check `pipeline-health.sh` after updates** to detect if patches were lost.
+- **The `< /dev/null` prevents** a "no stdin data received" warning in --print mode.
+- **Project hash discovery**: Use `git remote get-url origin | shasum -a 256 | cut -c1-12`
+  to find your project's instinct directory.
+- See also: `docs/solutions/integration-issues/chezmoi-scripts-deployment-gap-repo-only-vs-deployed-2026-04-04.md`
+  for related deployment pattern issues.


### PR DESCRIPTION
## Summary

- `ecc-observer-diagnosis` skill を chezmoi source tree (`dot_claude/skills/`) に追加
- これまで `~/.claude/skills/` に直接作成されていたため、新しいマシンにデプロイされなかった
- 既存の5つのローカル skill と同一パターン

## Test plan

- [x] `chezmoi managed | grep ecc-observer-diagnosis` で管理対象に含まれることを確認
- [x] `chezmoi diff` でソースとターゲットの差分がないことを確認
- [x] `chezmoi apply --dry-run` で他への影響がないことを確認

## Post-Deploy Monitoring & Validation

No additional operational monitoring required — purely additive file addition to the source tree with no runtime behavior change.