### PR TITLE
chore: remove default homebrew taps from Brewfile

### DIFF
--- a/darwin/Brewfile
+++ b/darwin/Brewfile
@@ -1,8 +1,6 @@
 tap "aws/tap"
 tap "coderabbitai/tap"
 tap "eugene1g/safehouse"
-tap "homebrew/bundle"
-tap "homebrew/services"
 tap "k1low/tap"
 tap "manaflow-ai/cmux"
 tap "theboredteam/boring-notch"


### PR DESCRIPTION
Remove `homebrew/bundle` and `homebrew/services` from Brewfile — these are default taps included with Homebrew and don't need explicit listing.

---

[![Compound Engineering v2.62.0](https://img.shields.io/badge/Compound_Engineering-v2.62.0-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 4.6 (1M context, extended thinking) via [Claude Code](https://claude.com/claude-code)