### PR TITLE
chore: snapshot 3 new instincts from security alerts debugging

### DIFF
--- a/dot_claude/instinct-snapshots/github-api-permission-debugging.md
+++ b/dot_claude/instinct-snapshots/github-api-permission-debugging.md
@@ -3,16 +3,25 @@ id: github-api-permission-debugging
 trigger: when debugging GitHub Actions workflow failures related to API permissions (403 errors, OIDC failures, token scope issues)
 confidence: 0.7
 domain: debugging
-tags: [github-actions, security, permissions]
-created: "2026-04-06"
+source: session-observation
+scope: project
+project_id: 23e6ae2f0a00
+project_name: chezmoi
 ---
 
 # GitHub API Permission Debugging Pattern
 
+## Action
 When a GitHub Actions workflow fails with permission errors (403, OIDC token failures):
 
 1. **Check the workflow's `permissions:` block first** — GitHub Actions defaults to read-only. Verify the workflow requests the specific permissions needed (e.g., `security-events: read` for code scanning alerts)
-2. **Distinguish GITHUB_TOKEN vs PAT scope** — Some GitHub APIs (Dependabot alerts, secret scanning) require a PAT with specific scopes; GITHUB_TOKEN cannot access them regardless of workflow permissions
+2. **Distinguish `GITHUB_TOKEN` vs non-`GITHUB_TOKEN` credentials** — Some GitHub APIs (for example, Dependabot alerts and secret scanning) cannot be accessed with `GITHUB_TOKEN` regardless of workflow permissions, and instead require another credential type such as a PAT or a GitHub App installation token
 3. **Use `gh run view --job=<id> --log` to inspect actual API calls** — Filter for error codes and permission-related messages
 4. **Check `gh api` locally first** — Test the exact API endpoint with your local token before debugging the workflow
-5. **For security-related APIs**, refer to GitHub docs for which token types are supported — the answer is often "PAT only"
+5. **For security-related APIs**, refer to GitHub docs for which token types are supported — in this repo, `.github/workflows/security-alerts.yml` uses a GitHub App installation token for Dependabot + secret scanning, while `GITHUB_TOKEN` is still used for code scanning
+
+## Evidence
+- Observed across 3 sessions debugging security-alerts.yml 403 errors (2026-04-05)
+- Pattern: GITHUB_TOKEN always fails for Dependabot/secret scanning APIs regardless of permissions block
+- Workflow now uses `actions/create-github-app-token` for elevated API access
+- Last observed: 2026-04-05

--- a/dot_claude/instinct-snapshots/github-api-permission-debugging.md
+++ b/dot_claude/instinct-snapshots/github-api-permission-debugging.md
@@ -1,0 +1,18 @@
+---
+id: github-api-permission-debugging
+trigger: when debugging GitHub Actions workflow failures related to API permissions (403 errors, OIDC failures, token scope issues)
+confidence: 0.7
+domain: debugging
+tags: [github-actions, security, permissions]
+created: "2026-04-06"
+---
+
+# GitHub API Permission Debugging Pattern
+
+When a GitHub Actions workflow fails with permission errors (403, OIDC token failures):
+
+1. **Check the workflow's `permissions:` block first** — GitHub Actions defaults to read-only. Verify the workflow requests the specific permissions needed (e.g., `security-events: read` for code scanning alerts)
+2. **Distinguish GITHUB_TOKEN vs PAT scope** — Some GitHub APIs (Dependabot alerts, secret scanning) require a PAT with specific scopes; GITHUB_TOKEN cannot access them regardless of workflow permissions
+3. **Use `gh run view --job=<id> --log` to inspect actual API calls** — Filter for error codes and permission-related messages
+4. **Check `gh api` locally first** — Test the exact API endpoint with your local token before debugging the workflow
+5. **For security-related APIs**, refer to GitHub docs for which token types are supported — the answer is often "PAT only"

--- a/dot_claude/instinct-snapshots/metadata.json
+++ b/dot_claude/instinct-snapshots/metadata.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-04-05T03:22:40Z",
+  "timestamp": "2026-04-05T16:00:05Z",
   "project_id": "23e6ae2f0a00",
   "project_name": "chezmoi",
-  "instinct_count": 8
+  "instinct_count": 11
 }

--- a/dot_claude/instinct-snapshots/security-alerts-workflow-pat-requirement.md
+++ b/dot_claude/instinct-snapshots/security-alerts-workflow-pat-requirement.md
@@ -3,18 +3,26 @@ id: security-alerts-workflow-pat-requirement
 trigger: when working on the security-alerts.yml workflow or any workflow that accesses Dependabot/code-scanning/secret-scanning APIs
 confidence: 0.75
 domain: workflow
-tags: [github-actions, security, pat]
-created: "2026-04-06"
+source: session-observation
+scope: project
+project_id: 23e6ae2f0a00
+project_name: chezmoi
 ---
 
-# Security Alerts Workflow Requires PAT for Dependabot API
+# Security Alerts Workflow Uses GitHub App Token for Dependabot and Secret Scanning APIs
 
-The GitHub REST API for Dependabot alerts (`/repos/{owner}/{repo}/dependabot/alerts`) returns 403 when accessed with GITHUB_TOKEN, even with `security-events: read` permission. This is a GitHub platform limitation.
+## Action
+The GitHub REST API for Dependabot alerts (`/repos/{owner}/{repo}/dependabot/alerts`) returns 403 when accessed with `GITHUB_TOKEN`, even with `security-events: read` permission. In this repository, the workflow addresses that limitation by generating a GitHub App token for Dependabot and secret-scanning API access, while code scanning continues to use `GITHUB_TOKEN`.
 
-**Solution:** Pre-fetch security alerts using a PAT in a separate job step, then pass the data to claude-code-action via environment variables or files. This avoids giving the PAT directly to the AI agent.
+**Solution:** Pre-fetch security alerts in a separate job step using a GitHub App token created via `actions/create-github-app-token`, then pass the data to `claude-code-action` via environment variables or files. This avoids giving the elevated GitHub App token directly to the AI agent.
 
 **Key pattern from `.github/workflows/security-alerts.yml`:**
-1. Step 1: Use PAT to call GitHub APIs and collect alert data
-2. Step 2: Pass pre-fetched data as context to claude-code-action (which uses GITHUB_TOKEN)
+1. Step 1: Use a GitHub App token to call the Dependabot and secret-scanning APIs and collect alert data
+2. Step 2: Pass pre-fetched data as context to `claude-code-action` (which uses `GITHUB_TOKEN`)
 
-This separation follows the principle of least privilege — the PAT is used only for the specific API calls that need it.
+This separation follows the principle of least privilege — the GitHub App token is used only for the specific API calls that need elevated access, while the downstream action continues using `GITHUB_TOKEN`.
+
+## Evidence
+- Observed during security-alerts.yml debugging when GITHUB_TOKEN returned 403 for Dependabot API (2026-04-05)
+- Workflow migrated from PAT to GitHub App token via `actions/create-github-app-token` in PR #147
+- Last observed: 2026-04-05

--- a/dot_claude/instinct-snapshots/security-alerts-workflow-pat-requirement.md
+++ b/dot_claude/instinct-snapshots/security-alerts-workflow-pat-requirement.md
@@ -1,0 +1,20 @@
+---
+id: security-alerts-workflow-pat-requirement
+trigger: when working on the security-alerts.yml workflow or any workflow that accesses Dependabot/code-scanning/secret-scanning APIs
+confidence: 0.75
+domain: workflow
+tags: [github-actions, security, pat]
+created: "2026-04-06"
+---
+
+# Security Alerts Workflow Requires PAT for Dependabot API
+
+The GitHub REST API for Dependabot alerts (`/repos/{owner}/{repo}/dependabot/alerts`) returns 403 when accessed with GITHUB_TOKEN, even with `security-events: read` permission. This is a GitHub platform limitation.
+
+**Solution:** Pre-fetch security alerts using a PAT in a separate job step, then pass the data to claude-code-action via environment variables or files. This avoids giving the PAT directly to the AI agent.
+
+**Key pattern from `.github/workflows/security-alerts.yml`:**
+1. Step 1: Use PAT to call GitHub APIs and collect alert data
+2. Step 2: Pass pre-fetched data as context to claude-code-action (which uses GITHUB_TOKEN)
+
+This separation follows the principle of least privilege — the PAT is used only for the specific API calls that need it.

--- a/dot_claude/instinct-snapshots/workflow-error-investigation-order.md
+++ b/dot_claude/instinct-snapshots/workflow-error-investigation-order.md
@@ -3,12 +3,15 @@ id: workflow-error-investigation-order
 trigger: when investigating GitHub Actions workflow failures
 confidence: 0.7
 domain: debugging
-tags: [github-actions, debugging]
-created: "2026-04-06"
+source: session-observation
+scope: project
+project_id: 23e6ae2f0a00
+project_name: chezmoi
 ---
 
 # Workflow Error Investigation Order
 
+## Action
 When a GitHub Actions workflow fails:
 
 1. **`gh run list --workflow=<name>.yml`** — Get recent run IDs and their status/conclusion
@@ -19,3 +22,8 @@ When a GitHub Actions workflow fails:
 6. **Test locally** — Run the same API calls or commands locally to isolate the issue
 
 Avoid reading full workflow logs without filtering — they can be massive. Always grep for error keywords first.
+
+## Evidence
+- Observed across 3+ sessions debugging security-alerts.yml and harness-analysis.yml (2026-04-05)
+- Pattern: Consistently used `gh run view --log-failed` before full logs, saving significant time
+- Last observed: 2026-04-05

--- a/dot_claude/instinct-snapshots/workflow-error-investigation-order.md
+++ b/dot_claude/instinct-snapshots/workflow-error-investigation-order.md
@@ -1,0 +1,21 @@
+---
+id: workflow-error-investigation-order
+trigger: when investigating GitHub Actions workflow failures
+confidence: 0.7
+domain: debugging
+tags: [github-actions, debugging]
+created: "2026-04-06"
+---
+
+# Workflow Error Investigation Order
+
+When a GitHub Actions workflow fails:
+
+1. **`gh run list --workflow=<name>.yml`** — Get recent run IDs and their status/conclusion
+2. **`gh run view <id> --log-failed`** — See only the failed step logs (much faster than full logs)
+3. **`gh run view --job=<job-id> --log`** with grep — Filter for specific error patterns
+4. **Check the workflow source** — `git log --oneline -5 -- .github/workflows/<name>.yml` to see recent changes
+5. **Compare with previous working version** — `git show <sha>:.github/workflows/<name>.yml`
+6. **Test locally** — Run the same API calls or commands locally to isolate the issue
+
+Avoid reading full workflow logs without filtering — they can be massive. Always grep for error keywords first.


### PR DESCRIPTION
## Summary
- Manually generated 3 new instincts from recent observations (observer pipeline is broken due to max-turns limitation with 30+ observations)
- New instincts capture patterns learned during security-alerts workflow debugging sessions:
  - `github-api-permission-debugging` — systematic approach for investigating GitHub Actions 403/OIDC failures
  - `security-alerts-workflow-pat-requirement` — documents PAT requirement for Dependabot API (GITHUB_TOKEN limitation)
  - `workflow-error-investigation-order` — ordered investigation steps for workflow failures

## Context
The ECC observer analysis is currently BROKEN (`Reached max turns (10)` with 30+ observations). Issue filed upstream: affaan-m/everything-claude-code#1240. These instincts were created manually following the ecc-observer-diagnosis skill procedure.

## Test plan
- [x] `scripts/snapshot-instincts.sh` ran successfully (11 instincts total)
- [x] `make lint` passes (pre-commit verified)
- [ ] auto-promote workflow can process these snapshots