### PR TITLE
fix: migrate .chezmoiexternal.toml from git-repo to archive for v2.70.1

### DIFF
--- a/.chezmoiexternal.toml
+++ b/.chezmoiexternal.toml
@@ -1,13 +1,13 @@
 [".claude/skills/claudeception"]
-  type = "git-repo"
-  url = "https://github.com/blader/Claudeception.git"
+  type = "archive"
+  url = "https://github.com/blader/Claudeception/archive/62dbb91d1183a866b5cf40079265c825b2695843.tar.gz"
   # renovate: branch=main
-  ref = "62dbb91d1183a866b5cf40079265c825b2695843"
+  stripComponents = 1
   refreshPeriod = "168h"
 
 [".local/share/cco"]
-  type = "git-repo"
-  url = "https://github.com/nikvdp/cco.git"
+  type = "archive"
+  url = "https://github.com/nikvdp/cco/archive/42fc44e5ecc0e26ef9068743b52485ebbcd54cf9.tar.gz"
   # renovate: branch=master
-  ref = "42fc44e5ecc0e26ef9068743b52485ebbcd54cf9"
+  stripComponents = 1
   refreshPeriod = "168h"

--- a/.claude/rules/renovate-external.md
+++ b/.claude/rules/renovate-external.md
@@ -9,7 +9,7 @@ Rules for managing external dependencies in `.chezmoiexternal.toml` with Renovat
 
 ## Renovate Contract
 
-All external entries use `type = "archive"` with SHA-embedded GitHub archive URLs. The regex custom manager in `renovate.json` requires these two lines to be **strictly adjacent in order** — no blank lines, no reordering:
+All external entries use `type = "archive"` with SHA-embedded GitHub archive URLs. The regex custom manager in `renovate.json` requires these two lines to appear **in order with no intervening keys or content** — only whitespace between them:
 
 ```toml
   url = "https://github.com/owner/repo/archive/full-sha-here.tar.gz"

--- a/.claude/rules/renovate-external.md
+++ b/.claude/rules/renovate-external.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-03-29
+date: 2026-04-12
 trigger: "Agent breaks Renovate adjacency contract in .chezmoiexternal.toml"
 ---
 
@@ -9,22 +9,25 @@ Rules for managing external dependencies in `.chezmoiexternal.toml` with Renovat
 
 ## Renovate Contract
 
-The regex custom manager in `renovate.json` requires these three lines to be **strictly adjacent in order** — no blank lines, no reordering:
+All external entries use `type = "archive"` with SHA-embedded GitHub archive URLs. The regex custom manager in `renovate.json` requires these two lines to be **strictly adjacent in order** — no blank lines, no reordering:
 
 ```toml
-  url = "https://github.com/owner/repo.git"
+  url = "https://github.com/owner/repo/archive/full-sha-here.tar.gz"
   # renovate: branch=main
-  ref = "full-sha-here"
 ```
 
 Breaking this adjacency silently disables Renovate auto-updates for that entry.
 
+**Why archive, not git-repo:** chezmoi's `git-repo` type has no `ref` field — there is no way to pin a `git-repo` entry to a specific commit. `type = "archive"` embeds the SHA in the URL, achieving actual supply-chain pinning. chezmoi v2.70.1+ enforces strict TOML parsing and rejects unknown fields.
+
 ## Adding a New External Entry
 
-1. Add the TOML block with `url`, `# renovate: branch=<branch>`, and `ref` in order
-2. Pin `ref` to a full commit SHA (not a tag or branch name)
-3. Include `refreshPeriod` for chezmoi's own refresh cycle
-4. Verify Renovate detects the entry: check the Renovate dashboard or dry-run
+1. Add the TOML block with `type = "archive"`
+2. Use a GitHub archive URL embedding the full commit SHA: `https://github.com/owner/repo/archive/<sha>.tar.gz`
+3. Add `# renovate: branch=<branch>` immediately after the `url` line
+4. Add `stripComponents = 1` to strip the archive's top-level directory
+5. Include `refreshPeriod` for chezmoi's own refresh cycle
+6. Verify Renovate detects the entry: check the Renovate dashboard or dry-run
 
 ## Existing Entries
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,7 +94,7 @@ Extensively excludes `~/.claude/` dynamic directories (projects, sessions, cache
 
 ### `.chezmoiexternal.toml`
 
-Pulls external git repos (e.g., Claudeception skill, cco) into the managed tree with auto-refresh. Each entry is pinned to a commit SHA via `ref` for supply-chain safety. Renovate auto-updates these SHAs — see `.claude/rules/renovate-external.md` for the adjacency contract that must be preserved.
+Pulls external archives (e.g., Claudeception skill, cco) into the managed tree with auto-refresh. Each entry uses `type = "archive"` with the commit SHA embedded in the GitHub archive URL for supply-chain safety. Renovate auto-updates these SHAs — see `.claude/rules/renovate-external.md` for the adjacency contract that must be preserved.
 
 ### Directory Layout
 

--- a/docs/plans/2026-04-12-001-fix-chezmoiexternal-strict-mode-plan.md
+++ b/docs/plans/2026-04-12-001-fix-chezmoiexternal-strict-mode-plan.md
@@ -1,0 +1,142 @@
+---
+title: "fix: Migrate .chezmoiexternal.toml from git-repo to archive for chezmoi v2.70.1 strict mode"
+type: fix
+status: active
+date: 2026-04-12
+---
+
+# fix: Migrate .chezmoiexternal.toml from git-repo to archive for chezmoi v2.70.1 strict mode
+
+## Overview
+
+chezmoi v2.70.1 introduced strict TOML parsing (commit `dd03362`) that rejects unknown fields in config files. The `ref` field used in `.chezmoiexternal.toml` is not a recognized field for `git-repo` type entries — it was silently ignored in prior versions. Migrate both entries from `type = "git-repo"` + `ref` to `type = "archive"` with SHA-pinned GitHub archive URLs, and update Renovate's regex custom manager to match the new URL pattern.
+
+## Problem Frame
+
+`chezmoi diff` (and all other chezmoi commands) fail with:
+```
+chezmoi: .chezmoiexternal.toml: strict mode: fields in the document are missing in the target struct
+```
+
+The `ref` field was never functional — chezmoi always cloned the default branch HEAD regardless of the `ref` value. This migration fixes the error and achieves actual SHA pinning for the first time.
+
+## Requirements Trace
+
+- R1. `chezmoi diff` and `chezmoi apply` must succeed without errors
+- R2. External entries must be pinned to specific commit SHAs (supply-chain safety)
+- R3. Renovate must continue auto-updating SHAs via the regex custom manager
+- R4. Target file paths must remain unchanged (`~/.claude/skills/claudeception/`, `~/.local/share/cco/`)
+- R5. `run_onchange_after_link-cco.sh.tmpl` must continue to work (it tracks `.chezmoiexternal.toml` hash)
+
+## Scope Boundaries
+
+- Only changing file format/type — not adding or removing external entries
+- Not modifying the `run_onchange_after_link-cco.sh.tmpl` script (it works as-is since it tracks the `.chezmoiexternal.toml` hash)
+- Not filing a chezmoi feature request for `git-repo` ref support (separate concern)
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `.chezmoiexternal.toml` — current git-repo entries with invalid `ref` field
+- `renovate.json` — regex custom manager matching `url + # renovate: branch= + ref` pattern
+- `.claude/rules/renovate-external.md` — documents the adjacency contract
+- `.chezmoiscripts/run_onchange_after_link-cco.sh.tmpl` — symlinks cco, tracks `.chezmoiexternal.toml` hash
+
+### Institutional Learnings
+
+- `docs/solutions/integration-issues/chezmoi-external-script-repo-with-renovate-sha-pinning.md` — original solution record for the `ref` pattern. Documents the Renovate adjacency contract, which needs updating.
+
+## Key Technical Decisions
+
+- **`type = "archive"` over alternative approaches**: Archive URLs embed the SHA directly in the URL, achieving actual pinning (unlike the broken `ref` field). `clone.args` cannot accept SHAs (`git clone --branch` only supports branches/tags). Archive type also eliminates `.git/` overhead in target directories.
+- **`stripComponents = 1`**: GitHub archive tarballs wrap contents in a `owner-repo-sha/` directory. `stripComponents = 1` strips this so files land directly in the target path, matching the previous `git-repo` layout.
+- **New Renovate adjacency contract**: URL line (containing SHA) + `# renovate: branch=` comment must remain adjacent. The `ref` line is removed entirely.
+
+## Implementation Units
+
+- [ ] **Unit 1: Migrate .chezmoiexternal.toml to archive type**
+
+**Goal:** Replace `type = "git-repo"` + `ref` with `type = "archive"` + SHA-embedded URL for both entries.
+
+**Requirements:** R1, R2, R4
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `.chezmoiexternal.toml`
+
+**Approach:**
+- Change `type` from `"git-repo"` to `"archive"` for both entries
+- Replace `url` with GitHub archive URL: `https://github.com/{owner}/{repo}/archive/{sha}.tar.gz`
+- Remove `.git` suffix from URL (archive URLs don't use it)
+- Remove `ref` field entirely
+- Add `stripComponents = 1` to preserve target directory structure
+- Keep `refreshPeriod` unchanged
+- Keep `# renovate: branch=` comment (now immediately after `url` line)
+
+**Test scenarios:**
+- Happy path: `chezmoi diff` completes without strict mode error
+- Happy path: `chezmoi apply --dry-run` shows no unexpected changes (or shows expected archive download)
+- Edge case: Verify target paths remain `~/.claude/skills/claudeception/` and `~/.local/share/cco/`
+
+**Verification:**
+- `chezmoi diff` succeeds without error
+- `chezmoi managed --path-style absolute | grep -E 'claudeception|cco'` shows expected paths
+
+- [ ] **Unit 2: Update Renovate regex custom manager**
+
+**Goal:** Update the regex pattern to extract depName, currentDigest, and currentValue from the new archive URL format.
+
+**Requirements:** R3
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `renovate.json`
+
+**Approach:**
+- New regex matches: `url = "https://github.com/{depName}/archive/{currentDigest}.tar.gz"` followed by `# renovate: branch={currentValue}`
+- `depName`: extracted from URL path (`owner/repo`)
+- `currentDigest`: SHA extracted from URL path (before `.tar.gz`)
+- `currentValue`: branch name from the `# renovate: branch=` comment
+- `datasourceTemplate` and `packageNameTemplate` remain unchanged (`git-refs`)
+
+**Test scenarios:**
+- Happy path: Renovate regex matches both entries in `.chezmoiexternal.toml` (verify via Renovate dry-run or local regex test)
+
+**Verification:**
+- Regex pattern correctly matches the new TOML format (testable locally with a regex tool)
+
+- [ ] **Unit 3: Update adjacency contract documentation**
+
+**Goal:** Update rule file and solution document to reflect the new archive-based format.
+
+**Requirements:** Accuracy of agent-facing documentation
+
+**Dependencies:** Unit 1, Unit 2
+
+**Files:**
+- Modify: `.claude/rules/renovate-external.md`
+- Modify: `docs/solutions/integration-issues/chezmoi-external-script-repo-with-renovate-sha-pinning.md`
+
+**Approach:**
+- Update the adjacency contract example in `renovate-external.md` to show the new URL + comment format
+- Update the "Adding a New External Entry" instructions
+- Add a note to the solution document about the v2.70.1 migration
+- Remove references to the `ref` field being functional
+
+**Test scenarios:**
+- Test expectation: none — documentation-only changes
+
+**Verification:**
+- Contract example in rule file matches actual `.chezmoiexternal.toml` format
+- `make lint` passes (no linting regressions)
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Existing git-cloned targets may conflict with archive extraction | If `chezmoi apply` fails, remove old targets (`~/.claude/skills/claudeception/`, `~/.local/share/cco/`) and re-apply |
+| Archive URL may behave differently from git-clone for large repos | Both repos are small; verified HTTP 200 for both archive URLs |
+| Renovate regex may not match on first try | Test regex locally before merging; Renovate dashboard shows match status |

--- a/docs/solutions/integration-issues/chezmoi-external-script-repo-with-renovate-sha-pinning.md
+++ b/docs/solutions/integration-issues/chezmoi-external-script-repo-with-renovate-sha-pinning.md
@@ -47,14 +47,16 @@ The mise `github:` backend **only works with repos that have GitHub Releases wit
 
 ```toml
 [".local/share/cco"]
-  type = "git-repo"
-  url = "https://github.com/nikvdp/cco.git"
+  type = "archive"
+  url = "https://github.com/nikvdp/cco/archive/0b7265e4d629328a558364d86bb6a7f9a16b050b.tar.gz"
   # renovate: branch=master
-  ref = "0b7265e4d629328a558364d86bb6a7f9a16b050b"
+  stripComponents = 1
   refreshPeriod = "168h"
 ```
 
-The `ref` field pins to a specific commit SHA for supply-chain safety.
+The commit SHA is embedded in the archive URL for supply-chain safety. `stripComponents = 1` strips the archive's top-level directory so files land directly in the target path.
+
+> **Note:** An earlier version used `type = "git-repo"` with a `ref` field. The `ref` field was never a valid chezmoi field for `git-repo` entries — it was silently ignored. chezmoi v2.70.1 introduced strict TOML parsing that rejects unknown fields, breaking this pattern. `type = "archive"` is the correct approach for SHA pinning.
 
 ### 2. Symlink script: `run_onchange_after_link-cco.sh.tmpl`
 
@@ -87,7 +89,7 @@ ln -sf "$CCO_BIN" "$LINK"
     "customType": "regex",
     "managerFilePatterns": ["/\\.chezmoiexternal\\.toml$/"],
     "matchStrings": [
-      "url\\s*=\\s*\"https://github\\.com/(?<depName>[^\"]+?)(?:\\.git)?\"\\s+#\\s*renovate:\\s*branch=(?<currentValue>\\S+)\\s+ref\\s*=\\s*\"(?<currentDigest>[a-f0-9]{40})\""
+      "url\\s*=\\s*\"https://github\\.com/(?<depName>[^/]+/[^/]+)/archive/(?<currentDigest>[a-f0-9]{40})\\.tar\\.gz\"\\s+#\\s*renovate:\\s*branch=(?<currentValue>\\S+)"
     ],
     "datasourceTemplate": "git-refs",
     "packageNameTemplate": "https://github.com/{{{depName}}}"
@@ -96,9 +98,9 @@ ln -sf "$CCO_BIN" "$LINK"
 ```
 
 The regex extracts:
-- `depName` from the `url` field (e.g., `nikvdp/cco`)
+- `depName` from the archive URL path (e.g., `nikvdp/cco`)
+- `currentDigest` (commit SHA) from the archive URL path
 - `currentValue` (branch name) from the `# renovate: branch=` comment
-- `currentDigest` (commit SHA) from the `ref` field
 
 Per-entry `# renovate: branch=` comments handle repos with different default branches (e.g., `main` vs `master`).
 
@@ -110,11 +112,11 @@ Hash-tracking comments like `# hash: {{ include "file" | sha256sum }}` **only wo
 
 ### 2. Renovate regex requires strict line adjacency
 
-The TOML entries must keep `url`, `# renovate: branch=`, and `ref` lines strictly adjacent with no intervening blank lines or other keys. TOML doesn't mandate key ordering, so reordering silently breaks Renovate matching. Document this contract in CLAUDE.md.
+The TOML entries must keep the `url` line (containing the SHA) and `# renovate: branch=` comment strictly adjacent with no intervening blank lines or other keys. TOML doesn't mandate key ordering, so reordering silently breaks Renovate matching. Document this contract in CLAUDE.md.
 
-### 3. `refreshPeriod` + `ref` interaction
+### 3. `refreshPeriod` + archive URL interaction
 
-When `ref` is set, `refreshPeriod` still controls how often chezmoi fetches — but since the ref is fixed, fetches are effectively no-ops until Renovate updates the SHA.
+`refreshPeriod` controls how often chezmoi re-downloads the archive. Since the SHA is embedded in the URL, re-downloads are effectively no-ops until Renovate updates the SHA in the URL.
 
 ### 4. Shebang consistency matters
 
@@ -122,7 +124,7 @@ Use `#!/usr/bin/env bash` (not `#!/bin/bash`) to match the repo convention. Caug
 
 ## Prevention
 
-- When adding new entries to `.chezmoiexternal.toml`, always include `ref` and `# renovate: branch=` comment
+- When adding new entries to `.chezmoiexternal.toml`, use `type = "archive"` with SHA-embedded URL and `# renovate: branch=` comment
 - Always use `run_onchange_after_` (not `run_after_`) for hash-tracked scripts
 - Keep the Renovate contract documented in CLAUDE.md
 - Verify Renovate `automerge` is disabled to maintain human review of SHA updates

--- a/docs/solutions/integration-issues/chezmoi-external-script-repo-with-renovate-sha-pinning.md
+++ b/docs/solutions/integration-issues/chezmoi-external-script-repo-with-renovate-sha-pinning.md
@@ -112,7 +112,7 @@ Hash-tracking comments like `# hash: {{ include "file" | sha256sum }}` **only wo
 
 ### 2. Renovate regex requires strict line adjacency
 
-The TOML entries must keep the `url` line (containing the SHA) and `# renovate: branch=` comment strictly adjacent with no intervening blank lines or other keys. TOML doesn't mandate key ordering, so reordering silently breaks Renovate matching. Document this contract in CLAUDE.md.
+The TOML entries must keep the `url` line (containing the SHA) and `# renovate: branch=` comment in order with no intervening keys or content (the regex uses `\s+`, which tolerates blank lines but not interleaved TOML keys). TOML doesn't mandate key ordering, so reordering silently breaks Renovate matching. Document this contract in CLAUDE.md.
 
 ### 3. `refreshPeriod` + archive URL interaction
 

--- a/docs/solutions/integration-issues/chezmoi-v2701-strict-mode-chezmoiexternal-migration-2026-04-12.md
+++ b/docs/solutions/integration-issues/chezmoi-v2701-strict-mode-chezmoiexternal-migration-2026-04-12.md
@@ -1,0 +1,102 @@
+---
+title: "chezmoi v2.70.1 strict mode rejects ref field in .chezmoiexternal.toml"
+date: 2026-04-12
+category: integration-issues
+module: chezmoi
+problem_type: integration_issue
+component: tooling
+symptoms:
+  - "chezmoi diff/apply fails: strict mode: fields in the document are missing in the target struct"
+  - "All chezmoi commands fail after upgrading to v2.70.1"
+root_cause: config_error
+resolution_type: config_change
+severity: high
+tags:
+  - chezmoi
+  - chezmoiexternal
+  - strict-mode
+  - archive
+  - renovate
+  - supply-chain-security
+  - harness-engineering
+---
+
+# chezmoi v2.70.1 strict mode rejects ref field in .chezmoiexternal.toml
+
+## Problem
+
+After upgrading chezmoi to v2.70.1 (via Homebrew auto-update), all chezmoi commands fail with:
+```
+chezmoi: .chezmoiexternal.toml: strict mode: fields in the document are missing in the target struct
+```
+
+## Symptoms
+
+- `chezmoi diff`, `chezmoi apply`, and all other commands fail immediately
+- Error points to `.chezmoiexternal.toml` as the source
+- The error message mentions "strict mode" and "fields missing in target struct"
+
+## What Didn't Work
+
+- The `ref` field was documented in project solution docs as a valid way to pin `git-repo` entries to specific commit SHAs. Investigation revealed it was **never a valid chezmoi field** for `git-repo` type entries. Previous chezmoi versions silently ignored unknown TOML fields, so the `ref` value was discarded without error. SHA pinning via `ref` never actually worked.
+
+## Solution
+
+Migrate from `type = "git-repo"` + `ref` to `type = "archive"` with SHA-embedded GitHub archive URLs.
+
+**Before (broken in v2.70.1):**
+
+```toml
+[".local/share/cco"]
+  type = "git-repo"
+  url = "https://github.com/nikvdp/cco.git"
+  # renovate: branch=master
+  ref = "42fc44e5ecc0e26ef9068743b52485ebbcd54cf9"
+  refreshPeriod = "168h"
+```
+
+**After:**
+
+```toml
+[".local/share/cco"]
+  type = "archive"
+  url = "https://github.com/nikvdp/cco/archive/42fc44e5ecc0e26ef9068743b52485ebbcd54cf9.tar.gz"
+  # renovate: branch=master
+  stripComponents = 1
+  refreshPeriod = "168h"
+```
+
+Key changes:
+- `type` changed from `"git-repo"` to `"archive"`
+- `url` now uses GitHub archive URL with SHA embedded: `https://github.com/{owner}/{repo}/archive/{sha}.tar.gz`
+- `ref` field removed entirely
+- `stripComponents = 1` added to strip the archive's top-level directory (e.g., `owner-repo-sha/`)
+- `.git` suffix removed from URL
+
+Also update the Renovate regex custom manager to match the new URL pattern:
+
+```json
+{
+  "matchStrings": [
+    "url\\s*=\\s*\"https://github\\.com/(?<depName>[^/]+/[^/]+)/archive/(?<currentDigest>[a-f0-9]{40})\\.tar\\.gz\"\\s+#\\s*renovate:\\s*branch=(?<currentValue>\\S+)"
+  ]
+}
+```
+
+GitHub archive URLs work for any commit SHA — no GitHub Releases required.
+
+## Why This Works
+
+chezmoi v2.70.1 introduced strict TOML parsing via commit [`dd03362`](https://github.com/twpayne/chezmoi/commit/dd03362165b4bbc6ff61cb89e2a5cb26a0d77647) ("Detect unknown fields when parsing config files"). The `ref` field was never part of chezmoi's internal struct for `git-repo` type entries — chezmoi's `git-repo` external type only supports `type`, `url`, `clone.args`, `pull.args`, and `refreshPeriod`. By switching to `type = "archive"` with the SHA in the URL, the commit is actually pinned (unlike the broken `ref` approach), and no unknown fields exist in the TOML.
+
+## Prevention
+
+- Use `type = "archive"` (not `git-repo`) when pinning to specific commit SHAs in `.chezmoiexternal.toml`
+- Check chezmoi release notes when upgrading — strict parsing may surface previously-silent config issues
+- Verify SHA pinning actually works by checking `chezmoi managed` output, not just trusting the config
+
+## Related Issues
+
+- [chezmoi v2.70.1 release notes](https://github.com/twpayne/chezmoi/releases/tag/v2.70.1)
+- [Managing script-only GitHub repos in chezmoi](chezmoi-external-script-repo-with-renovate-sha-pinning.md) — original setup guide, updated to reflect archive pattern
+- PR [#161](https://github.com/tanimon/dotfiles/pull/161) — the fix

--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,7 @@
       "customType": "regex",
       "managerFilePatterns": ["/\\.chezmoiexternal\\.toml$/"],
       "matchStrings": [
-        "url\\s*=\\s*\"https://github\\.com/(?<depName>[^\"]+?)(?:\\.git)?\"\\s+#\\s*renovate:\\s*branch=(?<currentValue>\\S+)\\s+ref\\s*=\\s*\"(?<currentDigest>[a-f0-9]{40})\""
+        "url\\s*=\\s*\"https://github\\.com/(?<depName>[^/]+/[^/]+)/archive/(?<currentDigest>[a-f0-9]{40})\\.tar\\.gz\"\\s+#\\s*renovate:\\s*branch=(?<currentValue>\\S+)"
       ],
       "datasourceTemplate": "git-refs",
       "packageNameTemplate": "https://github.com/{{{depName}}}"


### PR DESCRIPTION
## Summary

chezmoi v2.70.1 added strict TOML parsing ([`dd03362`](https://github.com/twpayne/chezmoi/commit/dd03362165b4bbc6ff61cb89e2a5cb26a0d77647)) that rejects unknown fields in config files. The `ref` field in `.chezmoiexternal.toml` was never a valid field for `git-repo` entries. It was silently ignored in prior versions, meaning SHA pinning never actually worked.

This PR switches both entries (Claudeception, cco) to `type = "archive"` with SHA-embedded GitHub archive URLs. This fixes the strict mode error and achieves actual commit pinning for the first time.

## Changes

- `.chezmoiexternal.toml`: `type = "git-repo"` + `ref` replaced with `type = "archive"` + `stripComponents = 1` and SHA in URL
- `renovate.json`: regex custom manager updated to extract `depName` and `currentDigest` from the new archive URL pattern
- `.claude/rules/renovate-external.md`: adjacency contract updated to the new two-line format (`url` + `# renovate: branch=`)
- `CLAUDE.md` and solution doc updated to reflect the archive pattern

## Verification

- `chezmoi diff` succeeds without strict mode error
- `chezmoi managed` shows unchanged target paths
- Renovate regex matches both entries (verified with perl regex test)
- `make lint` passes

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.6_(1M,_Extended_Thinking)-D97757?logo=claude&logoColor=white)