### PR TITLE
fix: allow sandbox access to ~/.gstack and Playwright cache

### DIFF
--- a/docs/plans/2026-04-13-003-fix-sandbox-gstack-access-plan.md
+++ b/docs/plans/2026-04-13-003-fix-sandbox-gstack-access-plan.md
@@ -1,0 +1,124 @@
+---
+title: "fix: Allow sandbox access to ~/.gstack/ directory"
+type: fix
+status: active
+date: 2026-04-13
+---
+
+# fix: Allow sandbox access to ~/.gstack/ directory
+
+## Overview
+
+Add `~/.gstack/` to the sandbox allow lists (safehouse and cco) so Claude Code can access gstack's runtime state directory from within the macOS Seatbelt sandbox.
+
+## Problem Frame
+
+Claude Code runs inside a deny-all macOS Seatbelt sandbox via safehouse (with cco as fallback). The gstack skill collection was recently added to this dotfiles repo, but its runtime state directory (`~/.gstack/`) was not added to the sandbox allow lists. This means Claude Code cannot read or write gstack's browser data, caches, or runtime artifacts, causing gstack skills (e.g., `/browse`) to fail with permission errors.
+
+## Requirements Trace
+
+- R1. Claude Code must be able to read and write `~/.gstack/` when running inside the safehouse sandbox
+- R2. Claude Code must be able to read and write `~/.gstack/` when running inside the cco fallback sandbox
+- R3. Follow existing patterns for adding working directories to both configs
+
+## Scope Boundaries
+
+- Only adding path entries — no changes to sandbox modules, wrappers, or architecture
+- No changes to `.chezmoiignore` (already excludes `.gstack` for chezmoi management)
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `dot_config/safehouse/config.tmpl` — Primary sandbox config. Working directories use `--add-dirs=` (read-write). Example: `--add-dirs={{ .chezmoi.homeDir }}/.codex` (line 34)
+- `dot_config/cco/allow-paths.tmpl` — Fallback sandbox config. Read-write paths have no `:ro` suffix. Example: `{{ .chezmoi.homeDir }}/.codex` (line 30)
+- Both configs use `{{ .chezmoi.homeDir }}` template variable for home directory
+
+### Institutional Learnings
+
+- `docs/solutions/integration-issues/migrate-cco-to-agent-safehouse.md` — safehouse is primary, cco is fallback; both must be updated in lockstep
+- `docs/solutions/runtime-errors/cco-sandbox-codex-mcp-eperm.md` — Same class of bug: missing allow entry for a runtime state directory (`.codex`). Fix pattern: add to both configs with read-write access
+
+## Key Technical Decisions
+
+- **Read-write access (not read-only)**: gstack writes browser state, caches, and session data to `~/.gstack/` at runtime. Read-only would break functionality. This matches the `.codex` and `.cache` entries.
+- **Both configs updated**: Safehouse is primary on macOS, but cco is the fallback. Both must be kept in sync per established practice.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Where to place the entry in safehouse config?** Under "Working directories (read-write)" section alongside `.codex` and `.cache` — gstack runtime state is the same category.
+- **Where to place the entry in cco config?** After the `.codex` entry with a comment explaining gstack runtime state.
+
+## Implementation Units
+
+- [x] **Unit 1: Add ~/.gstack/ to safehouse config**
+
+**Goal:** Allow read-write access to `~/.gstack/` in the primary sandbox.
+
+**Requirements:** R1, R3
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `dot_config/safehouse/config.tmpl`
+
+**Approach:**
+- Add `--add-dirs={{ .chezmoi.homeDir }}/.gstack` to the "Working directories (read-write)" section, after the `.codex` entry
+
+**Patterns to follow:**
+- Line 34: `--add-dirs={{ .chezmoi.homeDir }}/.codex` — same pattern for a tool's runtime state directory
+
+**Test scenarios:**
+- Happy path: `chezmoi execute-template` renders the config with the new entry containing the correct home directory path
+- Edge case: verify the entry does not duplicate any existing line
+
+**Verification:**
+- The rendered config includes `--add-dirs=<homeDir>/.gstack`
+- `chezmoi apply --dry-run` shows the expected diff
+
+- [x] **Unit 2: Add ~/.gstack/ to cco allow-paths**
+
+**Goal:** Allow read-write access to `~/.gstack/` in the fallback sandbox.
+
+**Requirements:** R2, R3
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `dot_config/cco/allow-paths.tmpl`
+
+**Approach:**
+- Add `{{ .chezmoi.homeDir }}/.gstack` (no `:ro` suffix = read-write) after the `.codex` entry, with a comment explaining gstack runtime state
+
+**Patterns to follow:**
+- Lines 29-30: `.codex` entry with comment — same pattern for a tool's runtime state directory
+
+**Test scenarios:**
+- Happy path: `chezmoi execute-template` renders the allow-paths with the new entry
+- Edge case: verify no `:ro` suffix is present (must be read-write)
+
+**Verification:**
+- The rendered allow-paths includes `<homeDir>/.gstack` without `:ro`
+- `chezmoi apply --dry-run` shows the expected diff
+
+## System-Wide Impact
+
+- **Interaction graph:** No callbacks or middleware affected — purely declarative config entries
+- **Error propagation:** If the entries are malformed, safehouse/cco will fail to launch (loud failure, easy to diagnose)
+- **State lifecycle risks:** None — adding allow entries is additive and safe
+- **API surface parity:** Both sandbox configs (safehouse + cco) must stay in sync
+- **Unchanged invariants:** All existing sandbox entries remain unchanged
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Typo in template variable breaks rendering | Follow exact pattern of adjacent entries; verify with `chezmoi apply --dry-run` |
+
+## Sources & References
+
+- Related code: `dot_config/safehouse/config.tmpl`, `dot_config/cco/allow-paths.tmpl`
+- Related PR: #162 (gstack introduction), #163 (bun via mise)
+- Learnings: `docs/solutions/runtime-errors/cco-sandbox-codex-mcp-eperm.md`

--- a/docs/solutions/integration-issues/sandbox-gstack-and-playwright-access-2026-04-13.md
+++ b/docs/solutions/integration-issues/sandbox-gstack-and-playwright-access-2026-04-13.md
@@ -1,0 +1,91 @@
+---
+title: Sandbox missing ~/.gstack and Playwright Chromium cache for gstack /browse skill
+date: 2026-04-13
+category: integration-issues
+module: sandbox
+problem_type: integration_issue
+component: tooling
+symptoms:
+  - "gstack /browse skill fails with permission errors inside safehouse sandbox"
+  - "Chromium binary at ~/Library/Caches/ms-playwright/ inaccessible from sandboxed Claude Code"
+root_cause: incomplete_setup
+resolution_type: config_change
+severity: medium
+related_components:
+  - development_workflow
+tags:
+  - sandbox
+  - safehouse
+  - cco
+  - seatbelt
+  - gstack
+  - playwright
+  - chromium
+  - harness-engineering
+---
+
+# Sandbox missing ~/.gstack and Playwright Chromium cache for gstack /browse skill
+
+## Problem
+
+After introducing gstack Claude Code skills (PR #162), the `/browse` skill could not function inside the macOS Seatbelt sandbox. Two distinct access gaps existed: the gstack runtime state directory (`~/.gstack/`) was missing from both sandbox configs (safehouse and cco), and the Playwright Chromium binary cache (`~/Library/Caches/ms-playwright/`) was inaccessible due to the deny-all safehouse policy.
+
+## Symptoms
+
+- gstack `/browse` skill fails with EPERM when trying to write browser state, session artifacts, or caches to `~/.gstack/`
+- Chromium cannot launch because the binary at `~/Library/Caches/ms-playwright/chromium-<version>/` is blocked by the sandbox
+- Even with `~/.gstack/` allowed, Chromium process IPC and GPU helpers fail without the `chromium-full`/`chromium-headless` sub-profiles
+
+## What Didn't Work
+
+- Adding only `~/.gstack/` to the sandbox configs resolves the state directory access but does not fix Chromium launch. The Playwright binary cache is a separate path (`~/Library/Caches/ms-playwright/`) not covered by any existing safehouse built-in profile.
+- Manually adding `~/Library/Caches/ms-playwright` as a path entry would grant file access but miss the Chromium process launch capabilities (`chromium-full`, `chromium-headless`) needed for IPC rendezvous sockets and GPU helpers.
+
+## Solution
+
+Four changes across two sandbox config files:
+
+**`dot_config/safehouse/config.tmpl`** (primary sandbox):
+```
+# Working directories (read-write)
+--add-dirs={{ .chezmoi.homeDir }}/.gstack
+
+# Integrations
+--enable=playwright-chrome
+```
+
+**`dot_config/cco/allow-paths.tmpl`** (fallback sandbox):
+```
+# gstack runtime state (browser data, caches, session artifacts)
+{{ .chezmoi.homeDir }}/.gstack
+# Playwright Chromium binary cache (needed for gstack /browse skill)
+{{ .chezmoi.homeDir }}/Library/Caches/ms-playwright:ro
+```
+
+The `--enable=playwright-chrome` safehouse module is the key: it covers `~/Library/Caches/ms-playwright` and also implies `chromium-full` and `chromium-headless`, enabling all the Chromium process launch capabilities in a single entry.
+
+## Why This Works
+
+The safehouse sandbox uses a deny-all Seatbelt policy. Any path not explicitly allowed is blocked. `~/.gstack/` needs read-write because gstack writes browser profiles, auth tokens, session queues, and logs there at runtime. The Playwright Chromium binary cache needs read access for the browser executable, plus process-level capabilities (IPC, GPU) that only the safehouse `playwright-chrome` module provides.
+
+For cco (fallback), the Playwright cache is added as `:ro` (read-only) since cco has no equivalent module system for process capabilities. On macOS (where safehouse is primary), the safehouse module handles everything. The cco entry provides path-level parity for Linux fallback, where the Playwright cache path differs (`~/.cache/ms-playwright/`, already covered by the existing `~/.cache` entry).
+
+## Prevention
+
+When adding a new tool to the sandbox, follow this checklist:
+
+1. **Identify the tool's own state directory** (e.g., `~/.gstack/`, `~/.codex/`) and add it to both configs
+2. **Trace transitive dependencies** -- does the tool launch sub-processes (browsers, language runtimes, build tools) that have their own cache directories?
+3. **Check for safehouse modules** -- run `safehouse --help` and look for a purpose-built module before manually adding paths. Modules bundle path access with process capabilities that manual `--add-dirs` cannot provide
+4. **Update both configs in lockstep** -- safehouse (primary) and cco (fallback) must stay in sync
+
+Prior art: The `~/.codex` addition followed the same pattern (see `docs/solutions/runtime-errors/cco-sandbox-codex-mcp-eperm.md`). This class of bug recurs every time a new tool is integrated.
+
+## Related Issues
+
+- `docs/solutions/runtime-errors/cco-sandbox-codex-mcp-eperm.md` -- same class of bug for Codex CLI
+- `docs/solutions/integration-issues/migrate-cco-to-agent-safehouse.md` -- safehouse architecture and migration
+- `docs/solutions/integration-issues/safehouse-cli-flag-internals-and-config-patterns.md` -- `--add-dirs` and `--enable` internals
+- `docs/solutions/integration-issues/chezmoi-external-skill-collection-patterns-2026-04-13.md` -- gstack integration pattern
+- PR #162 -- gstack introduction
+- PR #165 -- this fix

--- a/dot_config/cco/allow-paths.tmpl
+++ b/dot_config/cco/allow-paths.tmpl
@@ -28,6 +28,10 @@
 {{ .chezmoi.homeDir }}/.claude
 # Codex CLI config, credentials, skills, sessions, cache (codex MCP server)
 {{ .chezmoi.homeDir }}/.codex
+# gstack runtime state (browser data, caches, session artifacts)
+{{ .chezmoi.homeDir }}/.gstack
+# Playwright Chromium binary cache (needed for gstack /browse skill)
+{{ .chezmoi.homeDir }}/Library/Caches/ms-playwright:ro
 # chezmoi config and source directory (needed for chezmoi diff, managed, data, apply --dry-run)
 {{ .chezmoi.homeDir }}/.config/chezmoi:ro
 {{ .chezmoi.homeDir }}/.local/share/chezmoi:ro

--- a/dot_config/safehouse/config.tmpl
+++ b/dot_config/safehouse/config.tmpl
@@ -27,11 +27,13 @@
 --enable=shell-init
 --enable=clipboard
 --enable=process-control
+--enable=playwright-chrome
 
 # --- Working directories (read-write) ---
 --add-dirs={{ .chezmoi.homeDir }}/ghq
 --add-dirs={{ .chezmoi.homeDir }}/.cache
 --add-dirs={{ .chezmoi.homeDir }}/.codex
+--add-dirs={{ .chezmoi.homeDir }}/.gstack
 
 # --- Binaries and tools (read-only) ---
 # ~/.local/bin has claude symlink (covered by claude-code.sb as literal)


### PR DESCRIPTION
Claude Code running inside the macOS Seatbelt sandbox (safehouse/cco) couldn't access gstack's runtime state directory or launch Chromium for the `/browse` skill. Both `~/.gstack/` and the Playwright binary cache were missing from the sandbox allow lists.

Adds read-write access for `~/.gstack/` and enables the `playwright-chrome` safehouse module (which implies `chromium-full` and `chromium-headless` for Chromium process launch). The cco fallback config gets matching entries for parity, including read-only access to `~/Library/Caches/ms-playwright`.

## Test plan

- [ ] Run `chezmoi apply` to deploy updated configs
- [ ] Launch `claude` (sandboxed via safehouse) and run `/browse` to verify gstack can access `~/.gstack/` and launch Chromium
- [ ] Verify `safehouse --explain --stdout | grep -E 'gstack|playwright'` shows both rules

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.6_(1M,_Extended_Thinking)-D97757?logo=claude&logoColor=white)