### PR TITLE
fix: handle missing GitHub App secrets in security-alerts workflow

### DIFF
--- a/.github/workflows/security-alerts.yml
+++ b/.github/workflows/security-alerts.yml
@@ -57,19 +57,33 @@ jobs:
             echo "alert_type=all" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Check GitHub App availability
+        id: check-app
+        env:
+          APP_ID: ${{ secrets.SECURITY_APP_ID }} # zizmor: ignore[secrets-outside-env]
+          APP_PRIVATE_KEY: ${{ secrets.SECURITY_APP_PRIVATE_KEY }} # zizmor: ignore[secrets-outside-env]
+        run: |
+          if [ -n "$APP_ID" ] && [ -n "$APP_PRIVATE_KEY" ]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::SECURITY_APP_ID/SECURITY_APP_PRIVATE_KEY secrets not configured — Dependabot and secret-scanning alerts will be skipped"
+            echo "available=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Generate security alerts token
+        if: steps.check-app.outputs.available == 'true'
         id: app-token
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
           app-id: ${{ secrets.SECURITY_APP_ID }} # zizmor: ignore[secrets-outside-env]
           private-key: ${{ secrets.SECURITY_APP_PRIVATE_KEY }} # zizmor: ignore[secrets-outside-env]
-          permissions: >-
-            {"dependabot_alerts": "read", "secret_scanning_alerts": "read"}
+          permission-vulnerability-alerts: read
+          permission-secret-scanning-alerts: read
 
       - name: Gather security alerts
         id: alerts
         env:
-          # GitHub App token for Dependabot/Secret Scanning (GITHUB_TOKEN cannot access these)
+          # GitHub App token for Dependabot/Secret Scanning (empty when secrets are not configured)
           APP_TOKEN: ${{ steps.app-token.outputs.token }}
           # GITHUB_TOKEN works for code-scanning with security-events: read
           GH_DEFAULT_TOKEN: ${{ github.token }}
@@ -81,11 +95,16 @@ jobs:
           gather_alerts() {
             local type="$1" endpoint="$2" jq_filter="$3" token="$4"
             if [ "$scope" = "all" ] || [ "$scope" = "$type" ]; then
+              if [ -z "$token" ]; then
+                echo "::warning::Skipping $type alerts — GitHub App token not available (configure SECURITY_APP_ID and SECURITY_APP_PRIVATE_KEY secrets)" >&2
+                echo "[]"
+                return
+              fi
               local result
               if result=$(GH_TOKEN="$token" gh api "repos/$GITHUB_REPOSITORY/$endpoint" 2>&1); then
                 echo "$result" | jq -c "[.[] | select(.state == \"open\") | $jq_filter]"
               else
-                echo "::warning::Failed to fetch $type alerts: $result"
+                echo "::warning::Failed to fetch $type alerts: $result" >&2
                 errors="${errors}${type}: ${result}\n"
                 echo "[]"
               fi

--- a/docs/plans/2026-04-13-004-fix-security-alerts-app-token-plan.md
+++ b/docs/plans/2026-04-13-004-fix-security-alerts-app-token-plan.md
@@ -1,0 +1,158 @@
+---
+title: "fix: Handle missing GitHub App secrets and fix permission inputs in security-alerts workflow"
+type: fix
+status: active
+date: 2026-04-13
+---
+
+# fix: Handle missing GitHub App secrets and fix permission inputs in security-alerts workflow
+
+## Overview
+
+The `security-alerts.yml` workflow fails at the "Generate security alerts token" step because (1) the `SECURITY_APP_ID` / `SECURITY_APP_PRIVATE_KEY` repository secrets are not configured, and (2) the `permissions` input format is incompatible with `create-github-app-token@v2.2.2`. The fix makes the workflow degrade gracefully when the GitHub App is not configured, and corrects the permission input format for when it is.
+
+## Problem Frame
+
+GitHub Actions run [#24273060475](https://github.com/tanimon/dotfiles/actions/runs/24273060475/job/70881653371) fails with:
+
+```
+Error: [@octokit/auth-app] appId option is required
+```
+
+Two root causes:
+
+1. **Missing secrets**: `secrets.SECURITY_APP_ID` resolves to empty string because the repository secret is not configured. The `create-github-app-token` action requires a non-empty `app-id`.
+
+2. **Wrong input format**: The action uses individual `permission-*` inputs (e.g., `permission-vulnerability-alerts: read`), not a single `permissions` JSON blob. The current format triggers a warning but does not cause the failure on its own.
+
+## Requirements Trace
+
+- R1. The workflow must not fail when `SECURITY_APP_ID` / `SECURITY_APP_PRIVATE_KEY` secrets are absent
+- R2. When secrets are absent, code-scanning alerts (which work with `GITHUB_TOKEN`) must still be processed
+- R3. When secrets are present, the `create-github-app-token` step must use the correct `permission-*` input format
+- R4. The solution document must be updated to reflect the correct permission input format
+
+## Scope Boundaries
+
+- This fix does NOT set up the GitHub App or configure repository secrets — that is a manual step the user must perform separately
+- No changes to the `claude-code-action` prompt or the sweep logic
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `.github/workflows/security-alerts.yml` — the failing workflow
+- `docs/solutions/integration-issues/github-actions-security-alert-workflow-pitfalls-2026-04-02.md` — documents the GitHub App token approach but contains the incorrect `permissions` format
+
+### Institutional Learnings
+
+- The `GITHUB_TOKEN` cannot access Dependabot or secret-scanning APIs (documented in the solution file above)
+- `create-github-app-token@v2.2.2` accepts individual `permission-<name>: <level>` inputs, not a `permissions` JSON blob (from the workflow warning output)
+
+## Key Technical Decisions
+
+- **Conditional token generation via `if: secrets.SECURITY_APP_ID != ''`**: GitHub Actions evaluates `secrets.*` to empty string when the secret does not exist. This is the standard pattern for optional secret-dependent steps.
+- **Conditional alert gathering for Dependabot/secret-scanning**: When the app token is unavailable, these alert types are skipped entirely rather than failing. The `Gather security alerts` step checks whether `APP_TOKEN` is non-empty before calling restricted APIs.
+- **Individual `permission-*` inputs**: The `create-github-app-token@v2` action changed its input interface. Use `permission-vulnerability-alerts: read` and `permission-secret-scanning-alerts: read`.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Which permission inputs are correct?** The action's warning message lists valid inputs: `permission-vulnerability-alerts` (maps to Dependabot alerts) and `permission-secret-scanning-alerts`. Values are `read` or `write`.
+
+### Deferred to Implementation
+
+- None
+
+## Implementation Units
+
+- [x] **Unit 1: Add secret existence check and fix permission inputs**
+
+  **Goal:** Make the token generation step conditional and use the correct input format
+
+  **Requirements:** R1, R3
+
+  **Dependencies:** None
+
+  **Files:**
+  - Modify: `.github/workflows/security-alerts.yml`
+
+  **Approach:**
+  - Add `if: secrets.SECURITY_APP_ID != ''` to the "Generate security alerts token" step
+  - Replace `permissions: >- {"dependabot_alerts": "read", "secret_scanning_alerts": "read"}` with individual inputs: `permission-vulnerability-alerts: read` and `permission-secret-scanning-alerts: read`
+
+  **Patterns to follow:**
+  - Standard GitHub Actions pattern for optional secrets: `if: secrets.FOO != ''`
+
+  **Test scenarios:**
+  - Happy path: `actionlint` passes on the modified workflow
+  - Happy path: When secrets are configured, the step runs and generates a token with the correct permissions
+  - Edge case: When secrets are not configured, the step is skipped (not failed)
+
+  **Verification:**
+  - `actionlint .github/workflows/security-alerts.yml` produces no errors
+  - `make actionlint` passes
+
+- [x] **Unit 2: Make alert gathering handle missing app token**
+
+  **Goal:** When the GitHub App token is unavailable, skip Dependabot and secret-scanning alerts gracefully and process only code-scanning
+
+  **Requirements:** R1, R2
+
+  **Dependencies:** Unit 1
+
+  **Files:**
+  - Modify: `.github/workflows/security-alerts.yml`
+
+  **Approach:**
+  - In the "Gather security alerts" step, check if `APP_TOKEN` is non-empty before calling restricted APIs
+  - When empty, set Dependabot and secret-scanning arrays to `[]` with a warning message
+  - Code-scanning always uses `GITHUB_TOKEN` and proceeds regardless
+
+  **Test scenarios:**
+  - Happy path: When `APP_TOKEN` is available, all three alert types are fetched
+  - Edge case: When `APP_TOKEN` is empty, Dependabot and secret-scanning return `[]` with `::warning::` annotations, and code-scanning still works
+  - Edge case: The `has_alerts` output is correctly computed even when some arrays are empty due to missing token
+
+  **Verification:**
+  - The workflow completes successfully on the next scheduled run (or manual dispatch) even without the GitHub App configured
+
+- [x] **Unit 3: Update solution document with correct permission format**
+
+  **Goal:** Fix the incorrect `permissions` example in the existing solution document
+
+  **Requirements:** R4
+
+  **Dependencies:** Unit 1
+
+  **Files:**
+  - Modify: `docs/solutions/integration-issues/github-actions-security-alert-workflow-pitfalls-2026-04-02.md`
+
+  **Approach:**
+  - Update the YAML example in the "Solution" section to use individual `permission-*` inputs
+  - Add a note about the format change in `create-github-app-token@v2`
+
+  **Test expectation:** none -- documentation-only change
+
+  **Verification:**
+  - The example YAML matches the actual workflow syntax
+
+## System-Wide Impact
+
+- **Interaction graph:** No other workflows depend on the security alerts token step. The `claude-code-action` sweep step is downstream and receives pre-fetched data — unaffected by this change.
+- **Error propagation:** When the App token step is skipped, the `APP_TOKEN` env var is empty. The gather step must handle this explicitly rather than passing an empty token to `gh api`.
+- **Unchanged invariants:** The sweep job prompt, `claude-code-action` configuration, and code-scanning alert handling remain identical.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| `secrets.SECURITY_APP_ID != ''` may not evaluate correctly in all contexts | This is the standard GitHub Actions pattern for optional secrets, widely used and documented |
+| Skipping Dependabot/secret-scanning reduces coverage | The workflow logs `::warning::` annotations making the gap visible. Users are guided to set up the GitHub App |
+
+## Sources & References
+
+- Failed run: https://github.com/tanimon/dotfiles/actions/runs/24273060475/job/70881653371
+- Solution doc: `docs/solutions/integration-issues/github-actions-security-alert-workflow-pitfalls-2026-04-02.md`
+- `create-github-app-token` action: valid inputs listed in the workflow warning output

--- a/docs/plans/2026-04-13-004-fix-security-alerts-app-token-plan.md
+++ b/docs/plans/2026-04-13-004-fix-security-alerts-app-token-plan.md
@@ -9,7 +9,7 @@ date: 2026-04-13
 
 ## Overview
 
-The `security-alerts.yml` workflow fails at the "Generate security alerts token" step because (1) the `SECURITY_APP_ID` / `SECURITY_APP_PRIVATE_KEY` repository secrets are not configured, and (2) the `permissions` input format is incompatible with `create-github-app-token@v2.2.2`. The fix makes the workflow degrade gracefully when the GitHub App is not configured, and corrects the permission input format for when it is.
+The `security-alerts.yml` workflow fails at the "Generate security alerts token" step because (1) the `SECURITY_APP_ID` / `SECURITY_APP_PRIVATE_KEY` repository secrets are not configured, and (2) the `permissions` input format is incompatible with `create-github-app-token@v3.1.1`. The fix makes the workflow degrade gracefully when the GitHub App is not configured, and corrects the permission input format for when it is.
 
 ## Problem Frame
 
@@ -47,13 +47,13 @@ Two root causes:
 ### Institutional Learnings
 
 - The `GITHUB_TOKEN` cannot access Dependabot or secret-scanning APIs (documented in the solution file above)
-- `create-github-app-token@v2.2.2` accepts individual `permission-<name>: <level>` inputs, not a `permissions` JSON blob (from the workflow warning output)
+- `create-github-app-token@v3.1.1` accepts individual `permission-<name>: <level>` inputs, not a `permissions` JSON blob (from the workflow warning output)
 
 ## Key Technical Decisions
 
 - **Conditional token generation via `if: secrets.SECURITY_APP_ID != ''`**: GitHub Actions evaluates `secrets.*` to empty string when the secret does not exist. This is the standard pattern for optional secret-dependent steps.
 - **Conditional alert gathering for Dependabot/secret-scanning**: When the app token is unavailable, these alert types are skipped entirely rather than failing. The `Gather security alerts` step checks whether `APP_TOKEN` is non-empty before calling restricted APIs.
-- **Individual `permission-*` inputs**: The `create-github-app-token@v2` action changed its input interface. Use `permission-vulnerability-alerts: read` and `permission-secret-scanning-alerts: read`.
+- **Individual `permission-*` inputs**: The `create-github-app-token@v3` action changed its input interface from v2's `permissions` JSON blob. Use `permission-vulnerability-alerts: read` and `permission-secret-scanning-alerts: read`.
 
 ## Open Questions
 

--- a/docs/solutions/integration-issues/github-actions-security-alert-workflow-pitfalls-2026-04-02.md
+++ b/docs/solutions/integration-issues/github-actions-security-alert-workflow-pitfalls-2026-04-02.md
@@ -10,6 +10,8 @@ symptoms:
   - "GITHUB_TOKEN cannot access Dependabot alerts or Secret Scanning alerts API endpoints"
   - "claude-code-action jobs with no timeout-minutes consume runners indefinitely on hang"
   - "Agent completes successfully but creates 0 issues despite open alerts due to silent error suppression"
+  - "create-github-app-token fails with appId option is required when secrets are not configured"
+  - "::warning:: annotations inside shell functions corrupt JSON variables captured via $()"
 root_cause: config_error
 resolution_type: config_change
 severity: high
@@ -150,6 +152,53 @@ jobs:
 
 Use shorter timeouts for simpler jobs (e.g., `timeout-minutes: 15` for secret-scanning which only creates issues).
 
+**For missing GitHub App secrets (added 2026-04-13):**
+
+When `SECURITY_APP_ID`/`SECURITY_APP_PRIVATE_KEY` secrets are not configured, `create-github-app-token` fails with `[@octokit/auth-app] appId option is required`. Add a pre-check step to gate token generation and degrade gracefully:
+
+```yaml
+- name: Check GitHub App availability
+  id: check-app
+  env:
+    APP_ID: ${{ secrets.SECURITY_APP_ID }}
+    APP_PRIVATE_KEY: ${{ secrets.SECURITY_APP_PRIVATE_KEY }}
+  run: |
+    if [ -n "$APP_ID" ] && [ -n "$APP_PRIVATE_KEY" ]; then
+      echo "available=true" >> "$GITHUB_OUTPUT"
+    else
+      echo "::warning::GitHub App secrets not configured — restricted alerts will be skipped"
+      echo "available=false" >> "$GITHUB_OUTPUT"
+    fi
+
+- name: Generate security alerts token
+  if: steps.check-app.outputs.available == 'true'
+  # ...
+```
+
+Check **both** secrets — if only one is set, the token generation step runs but fails with a cryptic error rather than falling back gracefully. The `secrets` context is not available in step `if:` conditions, so use an env var check in a `run:` step instead.
+
+**For `::warning::` stdout corruption in shell function captures (added 2026-04-13):**
+
+When a shell function emits `echo "::warning::..."` and is called via `var=$(function_call)`, the warning text is captured into the variable alongside the intended output. This corrupts JSON variables and causes downstream `jq` parse failures:
+
+```bash
+# BAD: ::warning:: goes to stdout, captured into $dep along with []
+gather_alerts() {
+  echo "::warning::Skipping $type alerts"  # captured by $()!
+  echo "[]"
+}
+dep=$(gather_alerts ...)  # dep = "::warning::Skipping ...\n[]" — invalid JSON
+
+# GOOD: ::warning:: goes to stderr, only [] captured into $dep
+gather_alerts() {
+  echo "::warning::Skipping $type alerts" >&2  # bypasses $() capture
+  echo "[]"
+}
+dep=$(gather_alerts ...)  # dep = "[]" — valid JSON
+```
+
+GitHub Actions processes `::warning::` commands from the step's direct stdout/stderr streams, not from inside `$()` subshell captures. Redirecting to stderr (`>&2`) both fixes the variable corruption and ensures the annotation is rendered in the Actions UI.
+
 ## Why This Works
 
 The `GITHUB_TOKEN` limitation is a known GitHub platform constraint (see [community discussion #60612](https://github.com/orgs/community/discussions/60612)). The GitHub Actions App that generates `GITHUB_TOKEN` does not include Dependabot alerts or secret scanning alerts in its permission set. A dedicated GitHub App bypasses this by providing its own installation token with the required permissions. The `claude-code-action` OIDC-exchanged token also lacks these permissions — the Claude Code GitHub App's installation scope does not include security alert access.
@@ -168,6 +217,9 @@ The `timeout-minutes` fix prevents resource waste by ensuring jobs fail cleanly 
 - In shell scripts (summary steps, diagnostics), capture stderr with `2>&1` and set error state variables rather than discarding errors to `/dev/null`
 - Enable `show_full_output: true` during development of `claude-code-action` workflows to see the agent's reasoning; disable only after the workflow is proven stable
 - Consider a scheduled sweep job as a safety net for webhook events that may be missed
+- **Never emit `echo "::warning::..."` to stdout inside functions captured by `$()`** — redirect workflow annotations to stderr (`>&2`) so they bypass command substitution. This applies to any function whose output is assigned to a variable
+- **Gate optional action steps on secret availability** — use a dedicated check step that tests both required secrets via env vars, not `if: secrets.FOO != ''` (the `secrets` context is unavailable in step `if:` conditions). Check all related secrets together to prevent partial-configuration failures
+- **Verify action input format after version upgrades** — `create-github-app-token@v3` replaced the `permissions` JSON input with individual `permission-*` inputs. Unrecognized inputs are silently ignored, so the old format appears to work but produces a token without the requested permissions
 
 ## Related Issues
 
@@ -178,3 +230,4 @@ The `timeout-minutes` fix prevents resource waste by ensuring jobs fail cleanly 
 - [chezmoi-scripts-deployment-gap-repo-only-vs-deployed](./chezmoi-scripts-deployment-gap-repo-only-vs-deployed-2026-04-04.md) -- Analogous `|| true` error suppression anti-pattern
 - [PR #145](https://github.com/tanimon/dotfiles/pull/145) -- Fix that removed silent error suppression from security-alerts.yml
 - [PR #147](https://github.com/tanimon/dotfiles/pull/147) -- Pre-fetch alerts with GitHub App token to bypass GITHUB_TOKEN limitation
+- [PR #166](https://github.com/tanimon/dotfiles/pull/166) -- Fix missing secrets graceful degradation, v3 permission format, and stdout corruption

--- a/docs/solutions/integration-issues/github-actions-security-alert-workflow-pitfalls-2026-04-02.md
+++ b/docs/solutions/integration-issues/github-actions-security-alert-workflow-pitfalls-2026-04-02.md
@@ -66,8 +66,9 @@ Use a dedicated **GitHub App** with `actions/create-github-app-token` to generat
   id: check-app
   env:
     APP_ID: ${{ secrets.SECURITY_APP_ID }}
+    APP_PRIVATE_KEY: ${{ secrets.SECURITY_APP_PRIVATE_KEY }}
   run: |
-    if [ -n "$APP_ID" ]; then
+    if [ -n "$APP_ID" ] && [ -n "$APP_PRIVATE_KEY" ]; then
       echo "available=true" >> "$GITHUB_OUTPUT"
     else
       echo "available=false" >> "$GITHUB_OUTPUT"
@@ -76,7 +77,7 @@ Use a dedicated **GitHub App** with `actions/create-github-app-token` to generat
 - name: Generate security alerts token
   if: steps.check-app.outputs.available == 'true'
   id: app-token
-  uses: actions/create-github-app-token@v3
+  uses: actions/create-github-app-token@<sha> # v3
   with:
     app-id: ${{ secrets.SECURITY_APP_ID }}
     private-key: ${{ secrets.SECURITY_APP_PRIVATE_KEY }}

--- a/docs/solutions/integration-issues/github-actions-security-alert-workflow-pitfalls-2026-04-02.md
+++ b/docs/solutions/integration-issues/github-actions-security-alert-workflow-pitfalls-2026-04-02.md
@@ -1,7 +1,7 @@
 ---
 title: GitHub Actions security alert workflow pitfalls
 date: 2026-04-02
-last_updated: 2026-04-06
+last_updated: 2026-04-13
 category: integration-issues
 module: github-actions
 problem_type: integration_issue
@@ -60,14 +60,27 @@ Use a dedicated **GitHub App** with `actions/create-github-app-token` to generat
 **Pre-fetch pattern**: Gather alert data in a dedicated step before the `claude-code-action` agent, using the appropriate token per API:
 
 ```yaml
+- name: Check GitHub App availability
+  id: check-app
+  env:
+    APP_ID: ${{ secrets.SECURITY_APP_ID }}
+  run: |
+    if [ -n "$APP_ID" ]; then
+      echo "available=true" >> "$GITHUB_OUTPUT"
+    else
+      echo "available=false" >> "$GITHUB_OUTPUT"
+    fi
+
 - name: Generate security alerts token
+  if: steps.check-app.outputs.available == 'true'
   id: app-token
-  uses: actions/create-github-app-token@v2
+  uses: actions/create-github-app-token@v3
   with:
     app-id: ${{ secrets.SECURITY_APP_ID }}
     private-key: ${{ secrets.SECURITY_APP_PRIVATE_KEY }}
-    permissions: >-
-      {"dependabot_alerts": "read", "secret_scanning_alerts": "read"}
+    # v3 uses individual permission-* inputs (not a permissions JSON blob)
+    permission-vulnerability-alerts: read
+    permission-secret-scanning-alerts: read
 
 - name: Gather security alerts
   env:
@@ -75,11 +88,14 @@ Use a dedicated **GitHub App** with `actions/create-github-app-token` to generat
     GH_DEFAULT_TOKEN: ${{ github.token }}
   run: |
     # Use App token for Dependabot/Secret Scanning, github.token for code-scanning
+    # When APP_TOKEN is empty (secrets not configured), skip restricted APIs gracefully
     dep=$(GH_TOKEN="$APP_TOKEN" gh api repos/.../dependabot/alerts ...)
     cs=$(GH_TOKEN="$GH_DEFAULT_TOKEN" gh api repos/.../code-scanning/alerts ...)
     ss=$(GH_TOKEN="$APP_TOKEN" gh api repos/.../secret-scanning/alerts ...)
     # Write to /tmp/security-alerts.json for the agent to read
 ```
+
+**Note on `create-github-app-token` versions:** v2 accepted a `permissions` JSON input, but v3 replaced it with individual `permission-*` inputs (e.g., `permission-vulnerability-alerts: read`). Using the old `permissions` JSON in v3 produces a warning and the permissions are silently ignored.
 
 The agent reads pre-fetched data from a file instead of calling APIs directly, avoiding token permission issues entirely. Skip the agent step if no alerts are found (cost savings).
 


### PR DESCRIPTION
## Summary

- Add graceful degradation when `SECURITY_APP_ID`/`SECURITY_APP_PRIVATE_KEY` secrets are not configured — Dependabot and secret-scanning alerts are skipped with `::warning::` annotations, while code-scanning (using `GITHUB_TOKEN`) continues to work
- Fix `create-github-app-token@v3` permission inputs: replace invalid `permissions` JSON blob with individual `permission-vulnerability-alerts: read` and `permission-secret-scanning-alerts: read` inputs
- Fix stdout corruption: redirect `::warning::` annotations to stderr in `gather_alerts()` to prevent JSON variable poisoning via `$()` capture
- Check both `SECURITY_APP_ID` and `SECURITY_APP_PRIVATE_KEY` in availability gate to prevent partial-secret failures

Fixes: https://github.com/tanimon/dotfiles/actions/runs/24273060475/job/70881653371

## Test plan

- [x] `actionlint` passes
- [x] `make lint` passes (all checks green)
- [ ] Manual dispatch of security-alerts workflow succeeds (degrades gracefully when secrets absent)
- [ ] When GitHub App secrets are configured, Dependabot and secret-scanning alerts are fetched with correct permissions