### PR TITLE
fix: bypass codex internal sandbox inside safehouse Seatbelt

### DIFF
--- a/docs/plans/2026-04-13-004-fix-codex-nested-seatbelt-sandbox-plan.md
+++ b/docs/plans/2026-04-13-004-fix-codex-nested-seatbelt-sandbox-plan.md
@@ -1,0 +1,137 @@
+---
+title: "fix: Bypass codex internal sandbox inside safehouse Seatbelt"
+type: fix
+status: active
+date: 2026-04-13
+---
+
+# fix: Bypass codex internal sandbox inside safehouse Seatbelt
+
+## Overview
+
+When `codex` is invoked from within Claude Code (running inside safehouse's Seatbelt sandbox), codex tries to apply its own macOS Seatbelt sandbox via `sandbox-exec`, which fails because macOS denies nested `sandbox_apply` syscalls. Add a shell wrapper that detects the outer sandbox and automatically bypasses codex's internal sandbox.
+
+## Problem Frame
+
+The user creates a temp file with `mktemp` inside Claude Code and passes it to `codex` as input. Codex fails before it can read the file because its own sandbox initialization triggers `sandbox_apply`, which macOS denies when already inside a Seatbelt jail. This is the same class of issue as the Claude Code internal sandbox conflict documented in `docs/solutions/integration-issues/claude-code-internal-sandbox-nested-seatbelt-conflict.md`.
+
+## Requirements Trace
+
+- R1. `codex` CLI must function correctly when invoked from within a sandboxed Claude Code session (safehouse or cco)
+- R2. `codex` sandbox must remain active when invoked outside a Seatbelt sandbox (standalone use)
+- R3. Temp files created by `mktemp` must be readable by codex inside the sandbox
+
+## Scope Boundaries
+
+- Only addresses the nested sandbox conflict for `codex` CLI
+- Does not modify codex configuration files (`~/.codex/config.toml`)
+- Does not change safehouse or cco sandbox policies (they already allow `/tmp` and `$TMPDIR`)
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `dot_config/zsh/sandbox.zsh` — existing `claude()` wrapper function that adds safehouse/cco sandboxing. The `codex()` wrapper follows the inverse pattern: detecting an existing sandbox and disabling codex's internal one
+- `dot_claude/settings.json.tmpl` — Claude Code's internal sandbox disabled with `"sandbox": { "enabled": false }` to avoid the same nested Seatbelt conflict
+
+### Institutional Learnings
+
+- `docs/solutions/integration-issues/claude-code-internal-sandbox-nested-seatbelt-conflict.md` — identical root cause class. macOS denies nested `sandbox_apply`. Fix pattern: disable the inner sandbox when an outer sandbox already provides isolation
+- `docs/solutions/runtime-errors/cco-sandbox-codex-mcp-eperm.md` — prior codex sandbox issue (`~/.codex` not in allow-paths). Already resolved but confirms codex runs as a child process inside the sandbox
+
+## Key Technical Decisions
+
+- **Shell wrapper over config file**: A `codex()` shell function in `sandbox.zsh` is chosen over a managed `~/.codex/config.toml` because (1) the bypass should be conditional on being inside a sandbox, (2) config.toml cannot express conditional logic, and (3) the wrapper pattern already exists for `claude`
+- **`APP_SANDBOX_CONTAINER_ID` for detection**: This env var is set by macOS when any Seatbelt sandbox is active. Covers both safehouse and cco backends without tool-specific checks
+- **`--dangerously-bypass-approvals-and-sandbox` flag**: Codex's own documentation states this flag is "intended solely for running in environments that are externally sandboxed" — exactly this use case
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Does `/tmp` access need a sandbox config change?** No. Both safehouse and cco base policies unconditionally allow read-write to `/tmp`, `/private/tmp`, `/var/folders`, and `/private/var/folders`. `mktemp` on macOS uses `$TMPDIR` (under `/var/folders/`) by default, which is also covered
+- **Does the bypass flag work in all codex modes?** `codex exec --help` explicitly lists `--dangerously-bypass-approvals-and-sandbox`. The main `codex` help states "options will be forwarded to the interactive CLI", so it should work for interactive mode too. Verify during implementation
+- **Could codex detect the outer sandbox itself?** Codex could check `APP_SANDBOX_CONTAINER_ID` internally, but that requires an upstream change. The shell wrapper is the immediate fix
+
+### Deferred to Implementation
+
+- **Exact error message confirmation**: The plan assumes the error is `sandbox-exec: sandbox_apply: Operation not permitted` based on the identical Claude Code pattern. Verify the actual error during implementation
+
+## Implementation Units
+
+- [x] **Unit 1: Add codex wrapper to sandbox.zsh**
+
+**Goal:** Detect outer Seatbelt sandbox and bypass codex's internal sandbox automatically
+
+**Requirements:** R1, R2
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `dot_config/zsh/sandbox.zsh`
+
+**Approach:**
+- Add a `codex()` shell function after the existing `claude()` function
+- Check `$APP_SANDBOX_CONTAINER_ID` env var to detect outer Seatbelt sandbox
+- When inside sandbox: pass `--dangerously-bypass-approvals-and-sandbox` to codex
+- When outside sandbox: pass through to `command codex` unchanged
+- Include comment explaining the safety rationale (outer sandbox provides isolation)
+
+**Patterns to follow:**
+- `claude()` function in `dot_config/zsh/sandbox.zsh` for shell wrapper structure
+- `docs/solutions/integration-issues/claude-code-internal-sandbox-nested-seatbelt-conflict.md` for the "disable inner sandbox" pattern
+
+**Test scenarios:**
+- Happy path: `codex exec "echo hello"` succeeds inside a safehouse-sandboxed Claude Code session
+- Happy path: `mktemp` file created inside Claude Code is readable by codex via the wrapper
+- Happy path: `codex` invoked outside any sandbox runs with its own sandbox active (no bypass)
+- Edge case: `command codex` or `\codex` bypasses the wrapper for manual control
+
+**Verification:**
+- Inside sandboxed Claude Code: `codex exec "echo hello"` completes without `sandbox_apply: Operation not permitted`
+- Outside sandbox: `codex exec "echo hello"` uses codex's own sandbox (no `--dangerously-bypass-approvals-and-sandbox` in process args)
+
+- [x] **Unit 2: Document the solution**
+
+**Goal:** Record the solution for future reference and prevention
+
+**Requirements:** R1
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Create: `docs/solutions/integration-issues/codex-nested-seatbelt-sandbox-bypass.md`
+
+**Approach:**
+- Follow the existing solution document format (frontmatter with title, date, category, tags, module, symptom, root_cause)
+- Reference the Claude Code internal sandbox solution as the same root cause class
+- Include diagnostic and prevention guidance
+
+**Patterns to follow:**
+- `docs/solutions/integration-issues/claude-code-internal-sandbox-nested-seatbelt-conflict.md` for structure and format
+
+**Test scenarios:**
+Test expectation: none -- documentation file with no behavioral change
+
+**Verification:**
+- Solution doc exists with correct frontmatter and references the prior art
+
+## System-Wide Impact
+
+- **Interaction graph:** The wrapper intercepts all `codex` invocations in the user's shell. The `ecc:codex` skill and MCP server (`codex mcp-server`) are not affected — MCP server runs as a subprocess of Claude Code (not through the shell wrapper) and its sandbox conflict was already resolved in `settings.json.tmpl`
+- **Error propagation:** If `--dangerously-bypass-approvals-and-sandbox` is not recognized by a future codex version, codex will fail with an unknown flag error. The error is visible and diagnosable
+- **Unchanged invariants:** safehouse/cco sandbox policies are not modified. Claude Code's own sandbox configuration is not modified. Codex MCP server configuration is not modified
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| `--dangerously-bypass-approvals-and-sandbox` not accepted in interactive mode | Verify during implementation; fallback to `-c sandbox_type=none` or similar config override if needed |
+| Future codex updates change the flag name | The wrapper is in the chezmoi source tree and easy to update. Error would be visible |
+
+## Sources & References
+
+- Related code: `dot_config/zsh/sandbox.zsh` (existing sandbox wrapper)
+- Related solution: `docs/solutions/integration-issues/claude-code-internal-sandbox-nested-seatbelt-conflict.md`
+- Related solution: `docs/solutions/runtime-errors/cco-sandbox-codex-mcp-eperm.md`
+- Codex CLI help: `codex exec --help` documents `--dangerously-bypass-approvals-and-sandbox` as "intended solely for running in environments that are externally sandboxed"

--- a/docs/solutions/integration-issues/codex-nested-seatbelt-sandbox-bypass.md
+++ b/docs/solutions/integration-issues/codex-nested-seatbelt-sandbox-bypass.md
@@ -61,7 +61,7 @@ codex() {
 
 - **safehouse already provides comprehensive sandboxing** — deny-all default with granular allow rules
 - **The outer sandbox is strictly stronger** than codex's internal Seatbelt profile
-- **`command codex` or `\codex`** bypasses the wrapper for manual control when needed
+- **`command codex`** bypasses the wrapper for manual control when needed
 
 ## Prevention
 

--- a/docs/solutions/integration-issues/codex-nested-seatbelt-sandbox-bypass.md
+++ b/docs/solutions/integration-issues/codex-nested-seatbelt-sandbox-bypass.md
@@ -1,0 +1,69 @@
+---
+title: "Codex CLI nested Seatbelt sandbox conflict inside safehouse/cco"
+date: 2026-04-13
+category: integration-issues
+tags: [codex, sandbox, safehouse, cco, seatbelt, nested-sandbox, sandbox-exec, mktemp]
+module: sandbox configuration, codex CLI
+symptom: "sandbox-exec: sandbox_apply: Operation not permitted when running codex from within sandboxed Claude Code"
+root_cause: "Codex CLI applies its own macOS Seatbelt sandbox, which fails inside an existing Seatbelt sandbox because macOS denies nested sandbox_apply syscalls"
+---
+
+# Codex CLI nested Seatbelt sandbox conflict inside safehouse/cco
+
+## Problem
+
+When invoking `codex` from within a sandboxed Claude Code session (safehouse or cco), codex fails before processing any input:
+
+```
+sandbox-exec: sandbox_apply: Operation not permitted
+```
+
+This affects all codex modes (interactive, `exec`, `review`) and prevents using temp files (e.g., from `mktemp`) as input specifications for codex.
+
+## Root Cause
+
+Same class as the Claude Code internal sandbox conflict (`claude-code-internal-sandbox-nested-seatbelt-conflict.md`).
+
+Two independent sandbox layers conflict:
+
+1. **External sandbox (safehouse/cco)**: `sandbox.zsh` wraps `claude` with safehouse/cco, running Claude Code inside a Seatbelt sandbox via `sandbox-exec`
+2. **Internal sandbox (Codex CLI)**: Codex applies its own macOS Seatbelt sandbox for executing model-generated shell commands (`codex sandbox macos`)
+
+macOS denies nested `sandbox_apply` syscalls. When Codex (already inside safehouse's sandbox) tries to apply a second sandbox, the kernel returns EPERM.
+
+### Why `/tmp` access is not the issue
+
+Both safehouse and cco base policies unconditionally allow read-write to `/tmp`, `/private/tmp`, `/var/folders`, and `/private/var/folders`. `mktemp` on macOS creates files under `$TMPDIR` (typically `/var/folders/...`), which is already accessible. The error occurs before codex attempts to read any file — sandbox initialization itself fails.
+
+## Solution
+
+Add a `codex()` shell wrapper in `dot_config/zsh/sandbox.zsh` that detects the outer Seatbelt sandbox and bypasses codex's internal sandbox:
+
+```zsh
+codex() {
+  if [[ -n "$APP_SANDBOX_CONTAINER_ID" ]]; then
+    command codex --dangerously-bypass-approvals-and-sandbox "$@"
+  else
+    command codex "$@"
+  fi
+}
+```
+
+`$APP_SANDBOX_CONTAINER_ID` is set by macOS when any Seatbelt sandbox is active. The `--dangerously-bypass-approvals-and-sandbox` flag is documented by codex as "intended solely for running in environments that are externally sandboxed."
+
+### Why this is safe
+
+- **safehouse already provides comprehensive sandboxing** — deny-all default with granular allow rules
+- **The outer sandbox is strictly stronger** than codex's internal Seatbelt profile
+- **`command codex` or `\codex`** bypasses the wrapper for manual control when needed
+
+## Prevention
+
+When integrating a new CLI tool that uses macOS Seatbelt sandboxing internally, check whether it will run as a subprocess of an already-sandboxed process. If so, the tool needs a sandbox bypass option, and the wrapper should conditionally disable it.
+
+**Detection pattern**: `sandbox-exec: sandbox_apply: Operation not permitted` in stderr is the definitive signal of a nested Seatbelt conflict.
+
+## Related
+
+- [Claude Code internal sandbox conflicts with external Seatbelt sandbox](claude-code-internal-sandbox-nested-seatbelt-conflict.md) — identical root cause, same class of fix
+- [cco --safe sandbox: codex MCP server fails with EPERM on config.toml](../runtime-errors/cco-sandbox-codex-mcp-eperm.md) — prior codex sandbox issue (path access, not nested sandbox)

--- a/docs/solutions/integration-issues/codex-nested-seatbelt-sandbox-bypass.md
+++ b/docs/solutions/integration-issues/codex-nested-seatbelt-sandbox-bypass.md
@@ -2,10 +2,16 @@
 title: "Codex CLI nested Seatbelt sandbox conflict inside safehouse/cco"
 date: 2026-04-13
 category: integration-issues
-tags: [codex, sandbox, safehouse, cco, seatbelt, nested-sandbox, sandbox-exec, mktemp]
+problem_type: integration_issue
+component: tooling
+severity: high
 module: sandbox configuration, codex CLI
-symptom: "sandbox-exec: sandbox_apply: Operation not permitted when running codex from within sandboxed Claude Code"
-root_cause: "Codex CLI applies its own macOS Seatbelt sandbox, which fails inside an existing Seatbelt sandbox because macOS denies nested sandbox_apply syscalls"
+symptoms:
+  - "sandbox-exec: sandbox_apply: Operation not permitted when running codex from within sandboxed Claude Code"
+  - "All codex modes (interactive, exec, review) fail before processing input"
+root_cause: config_error
+resolution_type: config_change
+tags: [codex, sandbox, safehouse, cco, seatbelt, nested-sandbox, sandbox-exec, mktemp, harness-engineering]
 ---
 
 # Codex CLI nested Seatbelt sandbox conflict inside safehouse/cco

--- a/dot_config/zsh/sandbox.zsh
+++ b/dot_config/zsh/sandbox.zsh
@@ -44,7 +44,7 @@ _claude_cco() {
 # Bypass codex's internal Seatbelt sandbox when already inside an external sandbox.
 # macOS denies nested sandbox_apply syscalls — same root cause as the Claude Code
 # internal sandbox conflict. The outer sandbox (safehouse/cco) already provides isolation.
-# Use `command codex` or `\codex` to bypass this wrapper.
+# Use `command codex` to bypass this wrapper.
 codex() {
   if [[ -n "$APP_SANDBOX_CONTAINER_ID" ]]; then
     command codex --dangerously-bypass-approvals-and-sandbox "$@"

--- a/dot_config/zsh/sandbox.zsh
+++ b/dot_config/zsh/sandbox.zsh
@@ -40,3 +40,15 @@ _claude_cco() {
   fi
   command cco "${cco_args[@]}" "$@"
 }
+
+# Bypass codex's internal Seatbelt sandbox when already inside an external sandbox.
+# macOS denies nested sandbox_apply syscalls — same root cause as the Claude Code
+# internal sandbox conflict. The outer sandbox (safehouse/cco) already provides isolation.
+# Use `command codex` or `\codex` to bypass this wrapper.
+codex() {
+  if [[ -n "$APP_SANDBOX_CONTAINER_ID" ]]; then
+    command codex --dangerously-bypass-approvals-and-sandbox "$@"
+  else
+    command codex "$@"
+  fi
+}


### PR DESCRIPTION
## Summary

Codex CLI uses macOS Seatbelt for its internal sandbox. When invoked from within a sandboxed Claude Code session (safehouse or cco), the nested `sandbox_apply` syscall is denied by macOS, breaking all codex operations before they start. Same root cause class as the Claude Code internal sandbox conflict resolved in #157.

A `codex()` shell wrapper in `sandbox.zsh` now detects the outer Seatbelt sandbox via `$APP_SANDBOX_CONTAINER_ID` and passes `--dangerously-bypass-approvals-and-sandbox` to codex. The flag is documented by codex as "intended solely for running in environments that are externally sandboxed." Outside a sandbox, codex runs unchanged. `command codex` or `\codex` bypasses the wrapper for manual control.

## Test plan

- Inside sandboxed Claude Code: `codex exec "echo hello"` completes without `sandbox_apply: Operation not permitted`
- Outside sandbox: `codex exec "echo hello"` uses codex's own sandbox (no bypass flag in process args)
- `mktemp` file created inside Claude Code is readable by codex via the wrapper

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.6_(1M)-D97757?logo=claude&logoColor=white)