### PR TITLE
fix: clear "Plugin ecc not found" warning on Claude Code startup

### DIFF
--- a/.chezmoiscripts/run_onchange_after_install-ecc-rules.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_after_install-ecc-rules.sh.tmpl
@@ -4,6 +4,9 @@ set -euo pipefail
 
 # ecc-rules-languages hash: {{ include "dot_claude/ecc-rules-languages.txt" | sha256sum }}
 
+# ECC_ prefix is historical (from when the plugin was named "ecc"); the marketplace
+# directory "everything-claude-code" is the authoritative path and is unchanged by
+# the 2026-04-19 plugin rename. See docs/plans/2026-04-19-001-fix-ecc-plugin-rename-plan.md.
 ECC_MARKETPLACE_DIR="{{ .chezmoi.homeDir }}/.claude/plugins/marketplaces/everything-claude-code"
 
 if [ ! -d "$ECC_MARKETPLACE_DIR/rules" ]; then

--- a/docs/plans/2026-04-08-001-chore-sync-claude-settings-and-remove-deprecated-plugin-plan.md
+++ b/docs/plans/2026-04-08-001-chore-sync-claude-settings-and-remove-deprecated-plugin-plan.md
@@ -124,3 +124,7 @@ The active "Edit Source Files, Not Deployed Targets" instinct still applies — 
 - Source: `dot_claude/settings.json.tmpl`
 - Target: `~/.claude/settings.json`
 - Project rule: `CLAUDE.md` (chezmoi file pattern guidance)
+
+## Postscript (2026-04-19)
+
+The `everything-claude-code` marketplace reversed this rename: `ecc@everything-claude-code` no longer exists, and `everything-claude-code@everything-claude-code` is once again the authoritative plugin identifier. See `docs/plans/2026-04-19-001-fix-ecc-plugin-rename-plan.md` for the follow-up that re-adds the `everything-claude-code@everything-claude-code` enable entry. Treat the "deprecated" labels above as a snapshot of marketplace state on 2026-04-08, not a permanent classification.

--- a/docs/plans/2026-04-19-001-fix-ecc-plugin-rename-plan.md
+++ b/docs/plans/2026-04-19-001-fix-ecc-plugin-rename-plan.md
@@ -21,7 +21,7 @@ Update the chezmoi-managed `dot_claude/settings.json.tmpl` to enable the renamed
 
 ## Problem Frame
 
-`dot_claude/settings.json.tmpl` line 238 still has `"ecc@everything-claude-code": true` in `enabledPlugins`. The marketplace manifest (`~/.claude/plugins/marketplaces/everything-claude-code/.claude-plugin/marketplace.json`) now lists only `everything-claude-code` as an installable plugin name. Claude Code is therefore trying to enable a plugin that does not exist anymore.
+Before this fix, `dot_claude/settings.json.tmpl` line 238 had `"ecc@everything-claude-code": true` in `enabledPlugins`. The marketplace manifest (`~/.claude/plugins/marketplaces/everything-claude-code/.claude-plugin/marketplace.json`) now lists only `everything-claude-code` as an installable plugin name. Claude Code is therefore trying to enable a plugin that does not exist anymore.
 
 The runtime install state (`~/.claude/plugins/installed_plugins.json`) currently contains BOTH `ecc@everything-claude-code` (stale) and `everything-claude-code@everything-claude-code` (current, installed 2026-02-09, last-updated 2026-04-19). That file is intentionally NOT managed by chezmoi (per `CLAUDE.md` plugin install/enable state policy), so cleaning it up is a runtime user action, not part of the chezmoi diff.
 
@@ -92,7 +92,7 @@ The runtime install state (`~/.claude/plugins/installed_plugins.json`) currently
 
 **Test scenarios:**
 - Happy path: `make check-templates` succeeds — the template still parses with valid JSON output for all profiles.
-- Happy path: `chezmoi apply --dry-run` succeeds and shows the single expected diff for `~/.claude.json` (or whatever the deployed target is).
+- Happy path: `chezmoi apply --dry-run` succeeds and shows the single expected diff for `~/.claude/settings.json` (the deployed target of `dot_claude/settings.json.tmpl`).
 - Happy path: After `chezmoi apply`, opening Claude Code no longer prints the `Plugin "ecc" not found` warning, and the `everything-claude-code` plugin is listed as enabled by `claude plugin list`.
 - Edge case: `make lint` continues to pass (no new shellcheck/oxfmt/etc. regressions, since the change is JSON template content, not script logic).
 
@@ -106,7 +106,7 @@ The runtime install state (`~/.claude/plugins/installed_plugins.json`) currently
 - **State lifecycle risks:** None from chezmoi's side. However, `~/.claude/plugins/installed_plugins.json` retains a stale `ecc@everything-claude-code` entry. Until the user runs `claude plugin uninstall ecc@everything-claude-code` (or deletes the stale entry), Claude Code may continue to log the warning even after `chezmoi apply` because runtime install state and enable state are separate. Surface this in the PR description / runtime cleanup note.
 - **Unchanged invariants:**
   - `dot_claude/plugins/marketplaces.txt` is unchanged — `affaan-m/everything-claude-code` was and still is the correct marketplace.
-  - `.chezmoiscripts/run_onchange_after_install-ecc-rules.sh.tmpl` is unchanged — its hash remains stable, so it does not re-run; the rules directory layout is unaffected by the plugin rename.
+  - `.chezmoiscripts/run_onchange_after_install-ecc-rules.sh.tmpl` is touched by this PR for comment-only documentation (M1 fix from code review). The content-hash change will cause chezmoi to re-run the script once on the next `chezmoi apply`. The re-run is harmless — it copies the same ECC rules files into `~/.claude/rules/` idempotently, with no behavior change. The underlying rules-copy logic is unaffected by the plugin rename.
 
 ## Risks & Dependencies
 

--- a/docs/plans/2026-04-19-001-fix-ecc-plugin-rename-plan.md
+++ b/docs/plans/2026-04-19-001-fix-ecc-plugin-rename-plan.md
@@ -1,0 +1,129 @@
+---
+title: "fix: Update enabled plugin name from `ecc` to `everything-claude-code`"
+type: fix
+status: active
+date: 2026-04-19
+---
+
+# fix: Update enabled plugin name from `ecc` to `everything-claude-code`
+
+## Overview
+
+The `everything-claude-code` marketplace reorganized its plugin layout: the previous `ecc` plugin is gone, and the marketplace now exposes a single plugin named `everything-claude-code` (v1.10.0). Claude Code now logs the following on startup:
+
+```
+ecc @ everything-claude-code (user)
+      Plugin "ecc" not found in marketplace "everything-claude-code"
+      Plugin may not exist in marketplace "everything-claude-code"
+```
+
+Update the chezmoi-managed `dot_claude/settings.json.tmpl` to enable the renamed plugin and stop referencing the missing `ecc` plugin.
+
+## Problem Frame
+
+`dot_claude/settings.json.tmpl` line 238 still has `"ecc@everything-claude-code": true` in `enabledPlugins`. The marketplace manifest (`~/.claude/plugins/marketplaces/everything-claude-code/.claude-plugin/marketplace.json`) now lists only `everything-claude-code` as an installable plugin name. Claude Code is therefore trying to enable a plugin that does not exist anymore.
+
+The runtime install state (`~/.claude/plugins/installed_plugins.json`) currently contains BOTH `ecc@everything-claude-code` (stale) and `everything-claude-code@everything-claude-code` (current, installed 2026-02-09, last-updated 2026-04-19). That file is intentionally NOT managed by chezmoi (per `CLAUDE.md` plugin install/enable state policy), so cleaning it up is a runtime user action, not part of the chezmoi diff.
+
+## Requirements Trace
+
+- R1. `dot_claude/settings.json.tmpl` no longer enables the non-existent `ecc@everything-claude-code` plugin.
+- R2. The functionally equivalent plugin (`everything-claude-code@everything-claude-code`) is enabled in its place so the user keeps the same capabilities (rules, agents, skills) on next `chezmoi apply`.
+- R3. `chezmoi apply --dry-run` succeeds and `make lint` passes.
+- R4. The fix surfaces a clear runtime cleanup note for the user (uninstall the stale `ecc` entry) since chezmoi cannot do it.
+
+## Scope Boundaries
+
+- Out of scope: Modifying `installed_plugins.json` (runtime state, not chezmoi-managed).
+- Out of scope: Renaming `run_onchange_after_install-ecc-rules.sh.tmpl` or the `ECC_*` variable names in it. The script targets the marketplace directory (`~/.claude/plugins/marketplaces/everything-claude-code/rules`), not the plugin name. It still works correctly.
+- Out of scope: Renaming the `dot_claude/skills/ecc-observer-diagnosis/` skill — its name refers to the ECC continuous-learning observer (a hooks-based system bundled with the marketplace), not the plugin identifier.
+- Out of scope: Touching `dot_claude/ecc-rules-languages.txt` — its filename and contents are unaffected by the plugin rename.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `dot_claude/settings.json.tmpl` line 238 — the single line that needs to change.
+- `dot_claude/settings.json.tmpl` lines 226–239 — `enabledPlugins` map showing the existing key/value style to mirror.
+- `~/.claude/plugins/marketplaces/everything-claude-code/.claude-plugin/marketplace.json` — confirms the new authoritative plugin name.
+- `dot_claude/plugins/marketplaces.txt` — declarative marketplace list (already correct, no change needed).
+- `.chezmoiscripts/run_onchange_after_install-ecc-rules.sh.tmpl` — copies rules from the marketplace to `~/.claude/rules/`. Verified independent of plugin name (still functional after rename; rules directory exists at the same path).
+
+### Institutional Learnings
+
+- `docs/solutions/integration-issues/ecc-plugin-enablement-and-selective-rules-install-2026-04-03.md` — captures the original ECC plugin enablement approach. Worth a follow-up note that the plugin identifier changed, but not strictly required for this fix.
+- `CLAUDE.md` ("declarative marketplace sync"): plugin install/enable state files are explicitly NOT chezmoi-managed; only `enabledPlugins` in `settings.json.tmpl` is.
+
+## Key Technical Decisions
+
+- **Replace the key in place rather than removing it.** The user clearly wants the marketplace's plugin enabled (they had it on before the rename); replacing `ecc@everything-claude-code` with `everything-claude-code@everything-claude-code` preserves intent and keeps the rules/agents/skills available.
+- **Do not touch `installed_plugins.json` from chezmoi.** That file is runtime state. Surface the cleanup as a manual step in the PR description and the post-deploy note.
+
+## Open Questions
+
+### Resolved During Planning
+
+- "Does the rule-install script need updating?" — No. It targets the marketplace directory layout, not the plugin name. Verified by reading the script and listing `~/.claude/plugins/marketplaces/everything-claude-code/rules/`.
+- "Should the skill `ecc-observer-diagnosis` be renamed?" — No. It refers to the ECC continuous-learning observer feature, not the plugin identifier.
+
+### Deferred to Implementation
+
+- Whether to additionally update `docs/solutions/integration-issues/ecc-plugin-enablement-and-selective-rules-install-2026-04-03.md` with a postscript noting the rename. Decide during implementation; out of scope for the minimum fix but a candidate for a small follow-up.
+
+## Implementation Units
+
+- [ ] **Unit 1: Replace `ecc@everything-claude-code` with `everything-claude-code@everything-claude-code` in enabledPlugins**
+
+**Goal:** Stop trying to enable the non-existent `ecc` plugin; enable the renamed `everything-claude-code` plugin instead.
+
+**Requirements:** R1, R2
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `dot_claude/settings.json.tmpl`
+
+**Approach:**
+- Edit line 238: change the key `"ecc@everything-claude-code"` to `"everything-claude-code@everything-claude-code"`. Keep the value `true` and the surrounding formatting unchanged.
+- Keep the entry's position in the map (preserves diff readability).
+
+**Patterns to follow:**
+- Match the existing two-segment `<plugin>@<marketplace>: <bool>` style used elsewhere in the same `enabledPlugins` block (e.g., `"superpowers@claude-plugins-official": true`).
+
+**Test scenarios:**
+- Happy path: `make check-templates` succeeds — the template still parses with valid JSON output for all profiles.
+- Happy path: `chezmoi apply --dry-run` succeeds and shows the single expected diff for `~/.claude.json` (or whatever the deployed target is).
+- Happy path: After `chezmoi apply`, opening Claude Code no longer prints the `Plugin "ecc" not found` warning, and the `everything-claude-code` plugin is listed as enabled by `claude plugin list`.
+- Edge case: `make lint` continues to pass (no new shellcheck/oxfmt/etc. regressions, since the change is JSON template content, not script logic).
+
+**Verification:**
+- `grep -n 'ecc@everything-claude-code' dot_claude/settings.json.tmpl` returns no matches.
+- `grep -n 'everything-claude-code@everything-claude-code' dot_claude/settings.json.tmpl` returns exactly one match in the `enabledPlugins` block.
+
+## System-Wide Impact
+
+- **Interaction graph:** `dot_claude/settings.json.tmpl` is rendered by chezmoi into the user's Claude Code settings; the `enabledPlugins` map is read by Claude Code at startup. No other systems depend on the specific key `ecc@everything-claude-code`.
+- **State lifecycle risks:** None from chezmoi's side. However, `~/.claude/plugins/installed_plugins.json` retains a stale `ecc@everything-claude-code` entry. Until the user runs `claude plugin uninstall ecc@everything-claude-code` (or deletes the stale entry), Claude Code may continue to log the warning even after `chezmoi apply` because runtime install state and enable state are separate. Surface this in the PR description / runtime cleanup note.
+- **Unchanged invariants:**
+  - `dot_claude/plugins/marketplaces.txt` is unchanged — `affaan-m/everything-claude-code` was and still is the correct marketplace.
+  - `.chezmoiscripts/run_onchange_after_install-ecc-rules.sh.tmpl` is unchanged — its hash remains stable, so it does not re-run; the rules directory layout is unaffected by the plugin rename.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| User assumes `chezmoi apply` alone clears the warning, but stale runtime state in `installed_plugins.json` keeps it firing. | Call out the manual `claude plugin uninstall ecc@everything-claude-code` (and/or `claude plugin disable`) step in the PR description and runtime note. |
+| Future marketplace renames could repeat this issue. | Out of scope for this fix, but a future improvement could be a Make target that diffs `enabledPlugins` keys against the actual marketplace manifests. Note as a follow-up, not a blocker. |
+
+## Documentation / Operational Notes
+
+- After merge and `chezmoi apply`, advise the user to run `claude plugin uninstall ecc@everything-claude-code` to remove the stale entry from `installed_plugins.json` and silence the warning permanently.
+- Optional follow-up: append a postscript to `docs/solutions/integration-issues/ecc-plugin-enablement-and-selective-rules-install-2026-04-03.md` recording the 2026-04 rename so future readers understand the plugin identifier change.
+
+## Sources & References
+
+- Affected file: `dot_claude/settings.json.tmpl` (line 238)
+- Marketplace manifest (runtime, not in repo): `~/.claude/plugins/marketplaces/everything-claude-code/.claude-plugin/marketplace.json`
+- Runtime state (not chezmoi-managed): `~/.claude/plugins/installed_plugins.json`
+- Related solution doc: `docs/solutions/integration-issues/ecc-plugin-enablement-and-selective-rules-install-2026-04-03.md`
+- Related script (no change required): `.chezmoiscripts/run_onchange_after_install-ecc-rules.sh.tmpl`

--- a/dot_claude/settings.json.tmpl
+++ b/dot_claude/settings.json.tmpl
@@ -235,7 +235,7 @@
     "compound-engineering@compound-engineering-plugin": true,
     "ralph-loop@claude-plugins-official": true,
     "claude-md-management@claude-plugins-official": true,
-    "ecc@everything-claude-code": true
+    "everything-claude-code@everything-claude-code": true
   },
   "extraKnownMarketplaces": {
     "compound-engineering-plugin": {


### PR DESCRIPTION
## Summary

Claude Code 起動時に毎回出ていた以下の警告を解消します。

```
ecc @ everything-claude-code (user)
      Plugin "ecc" not found in marketplace "everything-claude-code"
      Plugin may not exist in marketplace "everything-claude-code"
```

`everything-claude-code` マーケットプレースは最近プラグイン構成を変更し、従来の `ecc` プラグインは廃止、現在は `everything-claude-code` という単一プラグイン (v1.10.0) のみを公開しています。`dot_claude/settings.json.tmpl` の `enabledPlugins` で古いキーを参照し続けていたため、Claude Code は存在しないプラグインを有効化しようとして警告を出していました。

提供される rules / agents / skills は同じマーケットプレース内に残っているため、キー名を新しいプラグイン名に置換するだけで機能は完全に等価です。

## What changed

- **`dot_claude/settings.json.tmpl`** — `enabledPlugins` のキーを `ecc@everything-claude-code` から `everything-claude-code@everything-claude-code` に置換 (1 行)。
- **`.chezmoiscripts/run_onchange_after_install-ecc-rules.sh.tmpl`** — `ECC_MARKETPLACE_DIR` 宣言の直前に「`ECC_` プレフィックスは旧プラグイン名の名残で、マーケットプレース側のディレクトリパス (`everything-claude-code`) は今回のリネームでも不変」である旨を 3 行コメントで明記。スクリプトはマーケットプレースのディレクトリ構造に依存しているのでロジック変更は不要。
- **`docs/plans/2026-04-08-001-...`** — 4/8 のプランで `everything-claude-code@everything-claude-code` を "deprecated" と記載していた箇所に 2026-04-19 の postscript を追記し、マーケットプレース側でリネームが巻き戻されたこと、および新プランへの相互参照を記録。
- **`docs/plans/2026-04-19-001-fix-ecc-plugin-rename-plan.md`** — 本修正の実装プランを新規追加。

## Manual cleanup (apply 後に必要)

`chezmoi apply` だけでは警告が完全には消えません。`~/.claude/plugins/installed_plugins.json` (chezmoi 管理外のランタイム状態) に古い `ecc@everything-claude-code` のエントリが残るためです。各マシンで一度だけ以下を実行してください。

```sh
claude plugin uninstall ecc@everything-claude-code
```

このファイルが chezmoi 管理外なのは設計通りです (`CLAUDE.md` の "declarative marketplace sync" 節を参照)。`enabledPlugins` (settings.json) と `installed_plugins.json` は別レイヤーで、後者はランタイムが所有します。

## Verification

- `make check-templates` PASS
- `make secretlint` PASS
- `make scan-sensitive` PASS
- `make test-scripts` PASS
- `chezmoi apply --dry-run` で `~/.claude/settings.json` の当該キー差分のみが出ることを確認

ローカルの `oxfmt` が未追跡の `.context/compound-engineering/ce-review/*` 由来で失敗しますが、以前のレビュー成果物による既存ノイズで本 PR とは無関係です。

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![HARNESS](https://img.shields.io/badge/Opus_4.7_(1M)-D97757?logo=claude&logoColor=white)