### PR TITLE
fix: pre-create ~/.gateguard/ to unbreak gateguard hook permanent-deny loop

### DIFF
--- a/docs/solutions/integration-issues/gateguard-fact-force-sandbox-state-dir-2026-04-19.md
+++ b/docs/solutions/integration-issues/gateguard-fact-force-sandbox-state-dir-2026-04-19.md
@@ -1,6 +1,7 @@
 ---
 title: GateGuard fact-forcing hook blocks every tool call when sandbox denies ~/.gateguard writes
 date: 2026-04-19
+last_updated: 2026-04-30
 category: integration-issues
 module: claude-code-harness
 problem_type: integration_issue
@@ -73,6 +74,8 @@ mkdir -p ~/.gateguard
 # then restart claude (exit + re-launch sandboxed claude)
 ```
 
+> **Update (2026-04-30):** the manual `mkdir -p ~/.gateguard` above is load-bearing for a reason that wasn't obvious in the original investigation — `agent-safehouse` auto-detects "file (literal) vs directory (subpath)" Seatbelt rule type at LAUNCH TIME, and silently emits an ineffective rule when an `--add-dirs` target doesn't exist on disk. So the manual `mkdir` is what makes the allowlist line actually take effect on first launch. The current canonical fix replaces the manual step with a chezmoi-managed placeholder (`dot_gateguard/dot_keep`) so the directory exists before `chezmoi apply` even finishes. See [`safehouse-add-dirs-requires-existing-path-2026-04-30.md`](safehouse-add-dirs-requires-existing-path-2026-04-30.md) for the full path-existence-trap explanation.
+
 Verification after restart:
 
 ```sh
@@ -91,6 +94,7 @@ Allowing the directory in both sandbox backends makes `fs.mkdirSync`/`fs.writeFi
 ## Prevention
 
 - **Any plugin hook that persists state must have its state directory audited against the sandbox allowlist.** Other candidates worth checking: `~/.claude-*`, plugin-local `.state`, `~/.config/*` write paths.
+- **Any sandbox `--add-dirs` target must exist at safehouse launch time.** safehouse auto-detects "literal file rule" vs "subpath rule" by stat-ing the path during profile generation; a non-existent path produces a silently ineffective rule. Pre-materialise via chezmoi (`dot_<name>/dot_keep` placeholder) rather than relying on the tool to `mkdir` at first use. Full mechanism: [`safehouse-add-dirs-requires-existing-path-2026-04-30.md`](safehouse-add-dirs-requires-existing-path-2026-04-30.md).
 - **Silent `catch (_)` around state writes is a harness smell.** Prefer logging to stderr (via a bounded rate limiter) so sandbox-induced state loss is observable. File as a potential upstream fix in `everything-claude-code`.
 - **When adding a new sandboxed tool, grep its source for `process.env.HOME`/`os.homedir()` and explicitly enumerate the paths it writes** before updating `safehouse/config.tmpl` and `cco/allow-paths.tmpl`.
 - **cco's `allow-paths` parser is whitespace-sensitive** — never indent entries even when visually grouping them under comments.
@@ -98,6 +102,7 @@ Allowing the directory in both sandbox backends makes `fs.mkdirSync`/`fs.writeFi
 
 ## Related Issues
 
+- `docs/solutions/integration-issues/safehouse-add-dirs-requires-existing-path-2026-04-30.md` — successor on the same hook + state dir, covering the path-existence-trap upstream cause that survives even after the allowlist is in place. Supersedes the manual `mkdir` step in this doc with a chezmoi-managed `dot_gateguard/dot_keep` placeholder.
 - `docs/solutions/integration-issues/cco-sandbox-chezmoi-read-only-access.md` — adjacent pattern: missing rw access for chezmoi runtime state.
 - `docs/solutions/integration-issues/claude-code-internal-sandbox-nested-seatbelt-conflict.md` — related class of failure: Claude Code's own sandbox colliding with outer sandboxing.
 - `docs/solutions/integration-issues/claude-code-hook-exit-code-and-stderr-semantics.md` — related harness-hook diagnostic guidance.

--- a/docs/solutions/integration-issues/safehouse-add-dirs-requires-existing-path-2026-04-30.md
+++ b/docs/solutions/integration-issues/safehouse-add-dirs-requires-existing-path-2026-04-30.md
@@ -1,0 +1,148 @@
+---
+title: "safehouse `--add-dirs` rule silently degrades when the path does not exist at sandbox launch"
+date: 2026-04-30
+category: integration-issues
+module: claude-code-harness
+problem_type: integration_issue
+component: tooling
+severity: high
+symptoms:
+  - "Every Bash/Edit/Write tool call hits the gateguard Fact-Forcing Gate first-call deny path indefinitely, even after presenting facts"
+  - "`~/.gateguard/state-<sessionid>.json` is never created on disk, despite `--add-dirs=$HOME/.gateguard` being present in `dot_config/safehouse/config`"
+  - "`sandboxd` log shows `deny(1) file-read-data /Users/.../.gateguard` AND `file-read-metadata` even AFTER the directory has been created from a non-sandboxed shell"
+  - "Manually `mkdir -p ~/.gateguard` mid-session does NOT recover the running claude session — only an exit + relaunch resolves it"
+  - "Same pattern would silently break any other tool whose runtime state dir is in `--add-dirs` but missing on disk at safehouse launch"
+root_cause: incomplete_setup
+resolution_type: environment_setup
+related_components:
+  - development_workflow
+tags:
+  - sandbox
+  - seatbelt
+  - agent-safehouse
+  - chezmoi
+  - gateguard
+  - everything-claude-code
+  - silent-failure
+  - runtime-state-dir
+---
+
+# safehouse `--add-dirs` rule silently degrades when the path does not exist at sandbox launch
+
+## Problem
+
+The `everything-claude-code:gateguard` PreToolUse hook (`zunoworks/gateguard`, bundled in ECC plugin v2.0.0-rc.1) entered a permanent-deny loop in this chezmoi-managed Claude Code setup: every `Bash`, `Edit`, and `Write` tool call was blocked with the "Fact-Forcing Gate" prompt indefinitely, even after the agent presented the requested facts. The gate could never transition from deny to allow because its state directory `~/.gateguard/` was unreachable from inside the agent-safehouse Seatbelt sandbox at runtime — and the predecessor fix of just adding the path to `--add-dirs` was insufficient because **the rule itself silently degrades when the path does not exist at safehouse launch time**.
+
+## Symptoms
+
+- Every Bash invocation returned the gate's first-call deny output asking the agent to "present these facts: 1. The current user request… 2. What this command verifies…", and presenting the facts had no effect — subsequent calls hit the same first-call branch.
+- Every Edit/Write/MultiEdit on a given file path returned the per-file fact-force gate, even on the second and third attempts.
+- `~/.gateguard/state-<sessionid>.json` was never created on disk (verified from a non-sandboxed terminal). `gateguard-fact-force.js` `saveState()` failed silently inside the catch block.
+- From a non-sandboxed terminal, `sudo log show --last 5m --predicate 'process == "sandboxd"'` showed (paths redacted):
+  ```text
+  20:32:58 deny(1) file-read-data <HOME>/.gateguard
+  20:32:58 deny(1) file-read-metadata <HOME>/.gateguard
+  ```
+  These denials happened **after** the user had created the dir from outside the sandbox — proving the running profile was stale.
+- The session was effectively frozen: no tool that triggers `pre:bash`, `pre:edit`, or `pre:write` hooks could execute.
+
+## What Didn't Work
+
+- **Hypothesis: per-call `session_id` drift.** Initial guess that `session_id` changed between calls and produced different state files. Disproved by reading `gateguard-fact-force.js:64` `resolveSessionKey()` — `data.session_id` is read directly from stdin and is deterministic across the session.
+- **Placeholder file with a literal leading dot.** First chezmoi fix attempt added `dot_gateguard/.keep` (literal `.keep`) to source. chezmoi treats source-side filenames starting with a literal `.` as unmanaged metadata, so the file never deployed:
+  ```sh
+  $ chezmoi managed | grep gateguard
+  .gateguard
+  $ chezmoi source-path ~/.gateguard/.keep
+  chezmoi: <HOME>/.gateguard/.keep: not managed
+  ```
+  The placeholder must use the `dot_` prefix (`dot_keep`) to materialise as `.keep` in the target.
+- **`mkdir -p ~/.gateguard` from inside the broken claude session via `!` prefix.** Returned `Operation not permitted` — `!`-prefixed commands run **inside** the agent-safehouse sandbox in this setup (auto memory [claude]: `bang_prefix_runs_inside_sandbox.md`), and the sandbox profile loaded at launch had no write rule for `~/.gateguard/`.
+- **`mkdir -p ~/.gateguard` from an external terminal, mid-session.** Created the directory on disk but did **not** rescue the running session: the Seatbelt profile is fixed at sandbox launch and is not re-evaluated when the underlying filesystem changes. Subsequent gate calls in the same session continued to hit `deny(1) file-read-*`.
+- **Workarounds considered and rejected:**
+  - `ECC_DISABLED_HOOKS=pre:bash:gateguard-fact-force` — disables a useful gate; doesn't fix the underlying class of bug for any other tool needing a runtime directory.
+  - `GATEGUARD_STATE_DIR=/tmp/.gateguard` — `/tmp` is also subject to safehouse rules and hits the same path-existence trap; volatile across reboots.
+  - `.chezmoiscripts/run_onchange_*` script that `mkdir`s the dir — overkill for a one-line guarantee; `dot_<name>/dot_keep` is the standard chezmoi idiom for "ensure empty dir exists".
+
+## Solution
+
+Add a single zero-byte placeholder file to the chezmoi source so `chezmoi apply` materialises `~/.gateguard/` **before** `claude` (and therefore `agent-safehouse`) launches.
+
+**Diff (PR #187)**
+
+New file:
+
+```text
+dot_gateguard/dot_keep   (0 bytes)
+```
+
+That's the entire fix. After `chezmoi apply`:
+
+```sh
+$ chezmoi managed | grep gateguard
+.gateguard
+.gateguard/.keep
+
+$ chezmoi source-path ~/.gateguard/.keep
+<CHEZMOI_SOURCE_DIR>/dot_gateguard/dot_keep
+
+$ ls -la ~/.gateguard/
+total 0
+drwxr-xr-x   3 <user>  staff    96 .
+drwxr-x---+ 80 <user>  staff  2560 ..
+-rw-r--r--   1 <user>  staff     0 .keep
+```
+
+No change is needed in `dot_config/safehouse/config.tmpl` — its existing `--add-dirs={{ "{{ .chezmoi.homeDir }}" }}/.gateguard` line is already correct. The fix removes the path-existence precondition that was breaking it.
+
+**Verification**
+
+- Restarted `claude` with `~/.gateguard/` pre-created on disk.
+- First Bash call: gate denied once with the fact-forcing prompt (expected).
+- Second Bash call after presenting facts: **allowed**.
+- `~/.gateguard/state-58e64a88-03f7-4494-8cbf-f5b261028032.json` was generated on the first call, confirming `saveState` succeeded.
+- `make lint` passed (`secretlint`, `shellcheck`, `shfmt`, `oxlint`, `oxfmt`, `actionlint`, `zizmor`, modify-script smoke tests, template render check, `scan-sensitive`).
+
+## Why This Works
+
+Three independent facts compose into the bug:
+
+1. **agent-safehouse `--add-dirs` is path-existence-sensitive at launch.** safehouse auto-detects "literal file rule" vs "subpath rule" by stat-ing each `--add-dirs` entry when it generates the Seatbelt profile (see `safehouse-cli-flag-internals-and-config-patterns.md`). If the path doesn't exist at launch, no effective subpath rule is emitted (auto memory [claude]: `safehouse_add_dirs_startup_path_existence.md`). The same Seatbelt-rule-shape sensitivity has bitten this setup before with `file-read-metadata` literal-vs-subpath (auto memory [claude]: `cco_seatbelt_file_read_metadata.md`).
+2. **gateguard silently swallows persistence errors.** `scripts/hooks/gateguard-fact-force.js` lines 128-183 wrap `mkdirSync` + `writeFileSync` + `renameSync` in `try { ... } catch (_) { /* ignore */ }`. EACCES from the sandbox is caught and discarded, so `saveState` becomes a no-op without surfacing any signal.
+3. **No persisted state ⇒ permanent first-call.** `isChecked('__bash_session__')` and per-file checks always read `false` from a never-written file, so every call lands on the deny branch.
+
+Pre-creating `~/.gateguard/` via a tracked chezmoi placeholder breaks fact #1: at the moment `claude` (and thus `agent-safehouse`) starts, the path exists and `--add-dirs` emits a real subpath rule. `mkdirSync`/`writeFileSync` inside the sandbox now succeed, `saveState` actually persists, and the deny→allow transition works as designed. Facts #2 and #3 still exist as latent risks but no longer trigger because the precondition is satisfied.
+
+The predecessor doc `gateguard-fact-force-sandbox-state-dir-2026-04-19.md` solved a different upstream cause (the `--add-dirs` line was missing from `safehouse/config.tmpl` entirely). Its "Solution" section recommends a manual `mkdir -p ~/.gateguard` before relaunching `claude`. That manual step happens to side-step this trap, but the doc doesn't explain *why* the `mkdir` is load-bearing — and a fresh-machine setup that runs `chezmoi apply` then `claude` without the manual step would still hit this bug. The new fix in this doc removes the manual step by making the directory tracked.
+
+## Prevention
+
+- **Use the `dot_<dir>/dot_keep` chezmoi idiom for any runtime directory that another tool's startup-time path-detection depends on.** Concretely:
+  ```text
+  dot_gateguard/dot_keep        # → ~/.gateguard/.keep   (creates ~/.gateguard/)
+  ```
+  Do **not** use a literal-dotted source filename like `dot_gateguard/.keep` — chezmoi treats literal-dot source filenames as unmanaged metadata (see `.claude/rules/chezmoi-patterns.md`, "File Type Selection"). Verify with `chezmoi managed | grep <dir>` after the change.
+- **When a tool's runtime directory must exist before sandbox launch, encode that as a tracked file, not a hook script.** A `dot_keep` placeholder is reviewable, deterministic, and incurs zero ordering risk. A `run_onchange_` `mkdir` script is heavier and won't help cases where the tool runs before the script (e.g., before first apply on a new machine).
+- **Audit `dot_config/safehouse/config.tmpl` `--add-dirs` entries against the source tree.** Every `--add-dirs={{ "{{ .chezmoi.homeDir }}" }}/<X>` line should have a corresponding `dot_<X>/dot_keep` (or other tracked content under `dot_<X>/`) that guarantees `~/.<X>/` exists on `chezmoi apply`. A future `make` target could grep both files and warn on mismatches.
+- **Upstream fail-loud suggestion (deferred, not in this PR).** Open a PR to zunoworks/gateguard or ECC plugin to log persistence failures instead of swallowing them silently. The minimal change in `scripts/hooks/gateguard-fact-force.js` ~line 174-181:
+  ```js
+  // before
+  try { /* mkdir + write + rename */ } catch (_) { /* ignore */ }
+
+  // after
+  try { /* mkdir + write + rename */ } catch (err) {
+    console.error(`[gateguard] saveState failed: ${err.message}`); // visible in PreToolUse stderr
+  }
+  ```
+  This would have surfaced the EACCES on the very first call and reduced diagnosis from hours to seconds.
+- **Heuristic for future debugging.** When a sandboxed tool exhibits "first-call always" behaviour with state-dir semantics, check `sudo log show --last 5m --predicate 'process == "sandboxd"'` from a non-sandboxed terminal **before** suspecting the tool's logic. Seatbelt deny lines are usually the fastest path to root cause and have caught both this issue and prior `file-read-metadata` regressions in this repo.
+- **In-session self-repair is impossible when Bash/Edit hooks are broken.** The recovery path must go through the host shell (a separate non-sandboxed terminal — `!` prefix runs INSIDE the sandbox in this setup, auto memory [claude]: `bang_prefix_runs_inside_sandbox.md`).
+
+## Related
+
+- `docs/solutions/integration-issues/gateguard-fact-force-sandbox-state-dir-2026-04-19.md` — predecessor on the same hook + same state dir. Solved the missing-allowlist upstream cause; this doc covers the path-existence-trap upstream cause that survives even after the allowlist is in place. The predecessor's "manual `mkdir -p ~/.gateguard`" step is now stale guidance — superseded by the chezmoi-managed approach here.
+- `docs/solutions/integration-issues/safehouse-cli-flag-internals-and-config-patterns.md` — explains the `policy_render_emit_path_ancestor_literals` / stat-based `-d` check that is the exact mechanism behind why a non-existent `--add-dirs` target silently degrades. Worth reading for background.
+- `docs/solutions/integration-issues/safehouse-daily-dev-paths-and-chezmoi-diff-eperm.md` — adjacent: same config file, same class of fix (allowlist rw path).
+- `docs/solutions/integration-issues/cco-sandbox-chezmoi-read-only-access.md` — adjacent runtime-state allowlist pattern.
+- `docs/solutions/integration-issues/claude-code-hook-exit-code-and-stderr-semantics.md` — silent-failure / hook-diagnostic guidance.
+- `docs/solutions/developer-experience/autonomous-harness-engineering-hooks-2026-03-28.md` — broader hook authoring context.


### PR DESCRIPTION
## Summary

`everything-claude-code:gateguard` の PreToolUse hook が **Bash / Edit / Write を毎回 deny し続ける** 永久 deny ループに陥る不具合を修正する。`~/.gateguard/` を chezmoi で事前作成することで、`claude` (safehouse 経由) 起動時に該当 path が必ず存在する状態を保証する。

## 不具合の再現と症状

任意の Bash 呼び出しで以下が無限に出続け、Bash も Edit/Write も成立しなくなる:

\`\`\`
[Fact-Forcing Gate]

Before the first Bash command this session, present these facts:
1. The current user request in one sentence
2. What this specific command verifies or produces
\`\`\`

事実を提示しても初回扱いから抜けず、操作不能。

## Root Cause

\`gateguard-fact-force.js\` は「初回提示済み」フラグを \`\$HOME/.gateguard/state-<sessionid>.json\` に永続化する。判定ロジック自体は正しい:

- 1 回目: \`isChecked('__bash_session__')\` = false → \`markChecked()\` → \`saveState()\` でディスク書込 → deny
- 2 回目以降: \`loadState()\` で flag を読む → allow

問題は **state 永続化が silent fail する** こと。原因チェーン:

1. ユーザー環境では \`claude\` が \`agent-safehouse\` (deny-all Seatbelt) でラップされている
2. \`dot_config/safehouse/config\` に \`--add-dirs=/Users/akito.tanikado/.gateguard\` を持つが、これは「file (literal) vs directory (subpath)」を起動時に自動判別する仕様
3. **claude 起動時点で \`~/.gateguard/\` が存在しない** と、subpath rule が emit されない（または literal で誤生成され）、後から dir を作っても既存プロファイルは更新されない
4. 結果、サンドボックス内の \`mkdirSync({recursive:true})\` / \`writeFileSync\` / \`readFileSync\` がすべて deny される
5. gate 側では \`saveState\` 全体が \`try { ... } catch (_) {}\` で握り潰され、上位は失敗を知り得ず毎回「初回」扱い → 永久 deny ループ

決定的証拠 (\`sudo log show --last 5m --predicate 'process == \"sandboxd\"'\`):

\`\`\`
20:32:58 deny(1) file-read-data /Users/akito.tanikado/.gateguard
20:32:58 deny(1) file-read-metadata /Users/akito.tanikado/.gateguard
\`\`\`

dir を非サンドボックス shell で作成しても既存 \`claude\` プロセス内では deny が解消せず、\`claude\` を再起動して初めてサンドボックスが新しい状態でルールを評価し、gate が正常動作することを確認。

## 修正内容

\`dot_gateguard/dot_keep\` を空ファイルとして追加。\`chezmoi apply\` 時に \`~/.gateguard/.keep\` が deploy されることで、副次的に \`~/.gateguard/\` が必ず存在状態になる。

注意点:

- chezmoi は **source 側のリーディングドット名 (\`.keep\`) を unmanaged metadata として扱う** ため、placeholder は必ず \`dot_keep\` (=> target \`.keep\`) でなければならない。\`dot_gateguard/.keep\` だと \`chezmoi managed\` に登場せず効果無し（PR 作成中に判明）。
- runtime 状態の \`state-*.json\` は source に存在しないので chezmoi は触らない（\`chezmoi managed\` には \`.gateguard\` と \`.gateguard/.keep\` のみ）。

## なぜこの方針か

代替案と却下理由:

| 案 | 却下理由 |
|---|---|
| \`ECC_DISABLED_HOOKS=pre:bash:gateguard-fact-force\` | gate 機能自体を捨てる。診断は不発のまま |
| \`GATEGUARD_STATE_DIR=/tmp/.gateguard\` | 揮発化・boot 毎に rule 不発リスク継続。\`/tmp\` も safehouse 配下で同種の罠 |
| \`.chezmoiscripts/run_onchange_*\` で mkdir | overkill。\`dot_<name>/dot_keep\` が chezmoi の標準 idiom |

## 上流改善余地（本 PR では実施しない）

\`gateguard-fact-force.js\` の \`saveState\`/\`loadState\` の \`catch (_) {}\` は失敗を完全に握り潰す設計欠陥。fail-loud にすべき。zunoworks/gateguard / ECC plugin への upstream PR が別途妥当。

## Test plan

- [x] \`make lint\` 全パス（exit 0、secretlint / shellcheck / shfmt / oxlint / oxfmt / actionlint / zizmor / modify_/scripts smoke / template / scan-sensitive すべて緑）
- [x] \`chezmoi managed | grep gateguard\` で \`.gateguard\` と \`.gateguard/.keep\` が一覧に出ること
- [x] \`chezmoi source-path ~/.gateguard/.keep\` が \`/Users/akito.tanikado/.local/share/chezmoi/dot_gateguard/dot_keep\` を返すこと
- [x] サンドボックス内で gate が deny → state file 永続化 → 次回 allow に遷移することを実機確認（\`~/.gateguard/state-58e64a88-03f7-4494-8cbf-f5b261028032.json\` 生成済み）
- [ ] マージ後、\`chezmoi apply\` を別マシンで初回適用したときに \`~/.gateguard/\` が claude 起動前に作られることを確認（要手動）

## 関連メモ

調査で得た再利用可能な知見を auto-memory に記録済:
- \`!\` プレフィックスは agent-safehouse サンドボックス内で実行される
- \`safehouse --add-dirs\` は path 不在時にルールを silent skip / mistype する