### PR TITLE
docs: fix stale rules directory reference in dot_claude/CLAUDE.md

### DIFF
--- a/dot_claude/CLAUDE.md
+++ b/dot_claude/CLAUDE.md
@@ -5,7 +5,7 @@
 
 # Rule Structure
 
-Detailed coding rules, test policies, and security guidelines live in `~/.claude/rules/`, organized by language (`golang/`, `typescript/`) and shared (`common/`). This file contains only cross-project behavioral guidelines.
+Detailed coding rules, test policies, and security guidelines live in `~/.claude/rules/`, organized by domain (`web/`) and shared (`common/`). This file contains only cross-project behavioral guidelines.
 
 # Compound Engineering Plugin Notes
 


### PR DESCRIPTION
## Summary
- `dot_claude/CLAUDE.md` で `~/.claude/rules/` の構成を `golang/`, `typescript/` と記載していたが、実際には存在しないディレクトリだった
- 実態（`common/` + `web/`）に合わせて `organized by domain (`web/`) and shared (`common/`)` に修正
- このファイルはデプロイ先 `~/.claude/CLAUDE.md` としてグローバル指示になるため、Claude が誤った場所を参照しに行くのを防ぐ

## Test plan
- [x] `make scan-sensitive` (191 files, no sensitive info)
- [x] pre-commit hooks (secretlint passed)
- [ ] CI lint passes