### PR TITLE
chore(helix): use night_owl theme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+.context/

--- a/dot_config/helix/config.toml
+++ b/dot_config/helix/config.toml
@@ -1,2 +1,4 @@
+theme = "night_owl"
+
 [editor.soft-wrap]
 enable = true


### PR DESCRIPTION
Sets `night_owl` as the helix editor theme.

Also adds `.context/` to `.gitignore` so compound-engineering session artifacts don't surface as untracked.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.7_%281M%29-D97757?logo=claude&logoColor=white)
