### PR TITLE
feat(zsh): add awsp for fzf-based AWS profile switching

### DIFF
--- a/dot_config/zsh/aws.zsh
+++ b/dot_config/zsh/aws.zsh
@@ -1,0 +1,41 @@
+# AWS profile switcher
+# `awsp`           : fzf で profile を選び AWS_PROFILE をこのシェルに export する
+# `awsp <name>`    : 指定した profile を直接設定する
+# `awsp -u|--unset`: AWS_PROFILE をクリアする
+# export なので bin/ スクリプトではなく関数として実装している（親シェルに反映するため）
+awsp() {
+  if [[ "$1" == "-u" || "$1" == "--unset" ]]; then
+    unset AWS_PROFILE
+    echo "AWS_PROFILE unset"
+    return 0
+  fi
+
+  local profile="$1"
+  if [[ -z "$profile" ]]; then
+    if ! command -v fzf &>/dev/null; then
+      echo "awsp: fzf is required but not installed" >&2
+      return 1
+    fi
+    profile="$(_awsp_list_profiles | fzf --height=40% --reverse \
+      --prompt='AWS profile> ' \
+      --header="current: ${AWS_PROFILE:-none}")" || return 0
+  fi
+
+  [[ -z "$profile" ]] && return 0
+  export AWS_PROFILE="$profile"
+  echo "AWS_PROFILE=$AWS_PROFILE"
+}
+
+# profile 一覧を取得（awscli があれば優先、無ければ設定ファイルを解析）
+_awsp_list_profiles() {
+  if command -v aws &>/dev/null; then
+    aws configure list-profiles
+    return
+  fi
+  local config="${AWS_CONFIG_FILE:-$HOME/.aws/config}"
+  local creds="${AWS_SHARED_CREDENTIALS_FILE:-$HOME/.aws/credentials}"
+  {
+    [[ -f "$config" ]] && sed -nE 's/^\[profile (.+)\]$/\1/p; s/^\[(default)\]$/\1/p' "$config"
+    [[ -f "$creds" ]] && sed -nE 's/^\[(.+)\]$/\1/p' "$creds"
+  } | awk 'NF && !seen[$0]++'
+}

--- a/dot_config/zsh/aws.zsh
+++ b/dot_config/zsh/aws.zsh
@@ -3,6 +3,7 @@
 # `awsp <name>`    : 指定した profile を直接設定する
 # `awsp -u|--unset`: AWS_PROFILE をクリアする
 # export なので bin/ スクリプトではなく関数として実装している（親シェルに反映するため）
+# profile 一覧の取得には aws CLI を前提とする（手書きの設定ファイル解析はしない）
 awsp() {
   if [[ "$1" == "-u" || "$1" == "--unset" ]]; then
     unset AWS_PROFILE
@@ -16,7 +17,17 @@ awsp() {
       echo "awsp: fzf is required but not installed" >&2
       return 1
     fi
-    profile="$(_awsp_list_profiles | fzf --height=40% --reverse \
+
+    # 一覧取得を fzf 起動前に行い、失敗(非ゼロ)・空のどちらも明示的に扱う。
+    # aws のエラーは fzf の TUI に混ざらず端末にそのまま出る。
+    local profiles
+    profiles="$(_awsp_list_profiles)" || return 1
+    if [[ -z "$profiles" ]]; then
+      echo "awsp: no AWS profiles found" >&2
+      return 1
+    fi
+
+    profile="$(printf '%s\n' "$profiles" | fzf --height=40% --reverse \
       --prompt='AWS profile> ' \
       --header="current: ${AWS_PROFILE:-none}")" || return 0
   fi
@@ -26,16 +37,11 @@ awsp() {
   echo "AWS_PROFILE=$AWS_PROFILE"
 }
 
-# profile 一覧を取得（awscli があれば優先、無ければ設定ファイルを解析）
+# profile 一覧を取得（aws CLI のみを使う。stdout に一覧、失敗時は非ゼロを返す）
 _awsp_list_profiles() {
-  if command -v aws &>/dev/null; then
-    aws configure list-profiles
-    return
+  if ! command -v aws &>/dev/null; then
+    echo "awsp: aws CLI is required but not installed" >&2
+    return 1
   fi
-  local config="${AWS_CONFIG_FILE:-$HOME/.aws/config}"
-  local creds="${AWS_SHARED_CREDENTIALS_FILE:-$HOME/.aws/credentials}"
-  {
-    [[ -f "$config" ]] && sed -nE 's/^\[profile (.+)\]$/\1/p; s/^\[(default)\]$/\1/p' "$config"
-    [[ -f "$creds" ]] && sed -nE 's/^\[(.+)\]$/\1/p' "$creds"
-  } | awk 'NF && !seen[$0]++'
+  aws configure list-profiles
 }

--- a/dot_zshrc
+++ b/dot_zshrc
@@ -1,6 +1,7 @@
 # PATH settings
 source ~/.config/zsh/path.zsh
 source ~/.config/zsh/sandbox.zsh
+source ~/.config/zsh/aws.zsh
 
 
 # Environment variables


### PR DESCRIPTION
複数の AWS profile を使い分ける際、毎回 `--profile <name>` を指定する手間をなくす。`awsp` を実行すると fzf で profile を選択でき、選んだ profile が現在のシェルの `AWS_PROFILE` に export されるため、以降の `aws` コマンドは指定なしでその profile を使う。`awsp <name>` で直接指定、`awsp -u` / `--unset` でクリアも可能。

profile 一覧は `aws configure list-profiles` から取得する（aws CLI を前提とし、手書きの設定ファイル解析はしない）。一覧の取得は fzf 起動前に行い、取得失敗時は aws のエラーをそのまま端末に出して中断、profile が 0 件のときは `no AWS profiles found` を明示する。無音で何も起きない挙動を避けている。

`export` を親シェルに反映する必要があるため `dot_local/bin/` のスクリプトではなく zsh 関数として実装し、既存の `sandbox.zsh` と同じく `dot_zshrc` から source している。

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![HARNESS](https://img.shields.io/badge/Opus_4.8_%281M%29-D97757?logo=claude&logoColor=white)
