### PR TITLE
chore: prune unused apps and sheldon plugin

### DIFF
--- a/darwin/Brewfile
+++ b/darwin/Brewfile
@@ -71,8 +71,5 @@ cask "meetingbar"
 cask "obsidian"
 cask "raycast"
 cask "visual-studio-code"
-mas "Keynote", id: 409183694
 mas "Menu Bar Calendar", id: 1558360383
-mas "Numbers", id: 361304891
-mas "Pages", id: 409201541
 mas "Portal", id: 1436994560

--- a/dot_config/sheldon/plugins.toml
+++ b/dot_config/sheldon/plugins.toml
@@ -12,9 +12,6 @@
 
 shell = "zsh"
 
-[plugins.wakatime]
-github = "sobolevn/wakatime-zsh-plugin"
-
 [plugins.zsh-completions]
 github = "zsh-users/zsh-completions"
 


### PR DESCRIPTION
## Summary

不要になったパッケージ・プラグインを整理します。Homebrew からは使っていない iWork アプリ（Keynote / Numbers / Pages）を、sheldon からは wakatime プラグインを削除しました。新規マシンのセットアップ時に無駄なインストールが走らなくなります。

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![HARNESS](https://img.shields.io/badge/Opus_4.8_%281M%29-D97757?logo=claude&logoColor=white)
