### PR TITLE
chore(claude): ecc の cost 警告 hook を無効化

### DIFF
--- a/dot_claude/settings.json.tmpl
+++ b/dot_claude/settings.json.tmpl
@@ -7,9 +7,11 @@
     "LANG": "ja_JP.UTF-8",
     {{/* CLV2_CONFIG: points the ecc plugin's continuous-learning observer at a config whose only live content is "enabled": false. Do NOT remove this env var or the config file — without them the plugin falls back to upstream defaults and the observer silently re-enables (the instinct pipeline was deliberately demolished in 2026-07). */ -}}
     "CLV2_CONFIG": "{{ .chezmoi.homeDir }}/.claude/continuous-learning-config.json",
-    {{/* _ZO_DOCTOR: Shell snapshot preserves zoxide cd function but not zsh chpwd_functions array, causing false-positive doctor warnings. */ -}}
     {{/* ECC_DISABLED_HOOKS: disable ecc (everything-claude-code) gateguard hook (issue #188). Both Bash and Edit/Write IDs are registered in separate dispatchers, so both must be listed. Hook IDs are plugin-name-independent, so they survive upstream plugin renames. */ -}}
     "ECC_DISABLED_HOOKS": "pre:bash:gateguard-fact-force,pre:edit-write:gateguard-fact-force",
+    {{/* ECC_CONTEXT_MONITOR_COST_WARNINGS: silence the COST NOTICE/WARNING/CRITICAL messages the ecc post:ecc-context-monitor hook injects at $5/$10/$50 session spend. This is a granular switch inside that hook — context-exhaustion, scope-creep, and tool-loop warnings from the same monitor stay active. To disable the whole monitor instead, add post:ecc-context-monitor to ECC_DISABLED_HOOKS above. */ -}}
+    "ECC_CONTEXT_MONITOR_COST_WARNINGS": "0",
+    {{/* _ZO_DOCTOR: Shell snapshot preserves zoxide cd function but not zsh chpwd_functions array, causing false-positive doctor warnings. */ -}}
     "_ZO_DOCTOR": "0"
   },
   "permissions": {


### PR DESCRIPTION
ecc プラグインが $5/$10/$50 のセッション支出で毎回注入していた COST NOTICE/WARNING/CRITICAL メッセージがセッション中に出なくなります。`ECC_CONTEXT_MONITOR_COST_WARNINGS=0` は `post:ecc-context-monitor` 内の cost 警告だけを止める granular なスイッチで、context 枯渇・scope creep・tool loop の警告と `stop:cost-tracker` によるコスト記録は従来どおり維持されます。

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.8_%281M%29-D97757?logo=claude&logoColor=white)
