### PR TITLE
chore(claude): settings.jsonのプラグインドリフトをsourceへ反映

### DIFF
--- a/dot_claude/settings.json.tmpl
+++ b/dot_claude/settings.json.tmpl
@@ -236,10 +236,8 @@
     "pr-review-toolkit@claude-plugins-official": true,
     "plugin-dev@claude-plugins-official": false,
     "planning-with-files@planning-with-files": false,
-    "gopls-lsp@claude-plugins-official": true,
     "feature-dev@claude-plugins-official": false,
     "commit-commands@claude-plugins-official": true,
-    "claude-delegator@jarrodwatts-claude-delegator": false,
     "compound-engineering@compound-engineering-plugin": true,
     "ralph-loop@claude-plugins-official": true,
     "claude-md-management@claude-plugins-official": true,
@@ -272,12 +270,6 @@
         "repo": "anthropics/skills"
       },
       "autoUpdate": true
-    },
-    "jarrodwatts-claude-delegator": {
-      "source": {
-        "source": "github",
-        "repo": "jarrodwatts/claude-delegator"
-      }
     },
     "planning-with-files": {
       "source": {


### PR DESCRIPTION
`~/.claude/settings.json`(ライブ)に存在しない `gopls-lsp` / `claude-delegator` プラグインと `jarrodwatts-claude-delegator` マーケットプレイスが、ソーステンプレートにのみ残存していた。この状態では `chezmoi apply` がこれらを不要に再登録してしまう。

ソースをライブ状態に合わせて3エントリを削除し、ドリフトを解消。レンダリング結果が valid JSON であること、`chezmoi diff` にプラグイン関連差分が残らないことを確認済み。

#214（target のみに存在したエントリを source へ反映）と対になる、逆方向のドリフト同期。

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.8_%281M%29-D97757?logo=claude&logoColor=white)
