### PR TITLE
docs(claude): Compound Engineering セクション削除と AskUserQuestion 利用方針を追加

### DIFF
--- a/dot_claude/CLAUDE.md
+++ b/dot_claude/CLAUDE.md
@@ -7,6 +7,6 @@
 
 Detailed coding rules, test policies, and security guidelines live in `~/.claude/rules/`, organized by domain (`web/`) and shared (`common/`). This file contains only cross-project behavioral guidelines.
 
-# Compound Engineering Plugin Notes
+# Asking the User
 
-The `ralph-wiggum` skill may appear as `ralph-loop`. Launch via `/ralph-loop:ralph-loop`.
+When you need the user to confirm a decision or choose between options, prefer the `AskUserQuestion` tool over free-form prose questions. It gives the user structured, selectable choices and keeps decisions explicit. Reserve free-form questions for cases the tool cannot express (e.g., open-ended input).


### PR DESCRIPTION
## 概要

グローバル `~/.claude/CLAUDE.md`(chezmoi ソース: `dot_claude/CLAUDE.md`)に対して以下の 2 点を変更しました。

## 変更内容

- **`Compound Engineering Plugin Notes` セクションを削除**
  - `ralph-wiggum` / `ralph-loop` に関する記述を含むセクションごと削除。
- **`Asking the User` セクションを追加**
  - ユーザーへの確認・選択肢提示が必要な場面では、自由記述の質問よりも `AskUserQuestion` ツールを優先するよう明文化。
  - 「いつ使うか」「なぜ使うか(選択が明示的になる)」「例外(自由入力が必要な場合)」を含む簡潔なルール。

## 補足

- エージェント向けドキュメントのため、`documentation-language.md` のルールに従い追記は英語で記述しています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)