### PR TITLE
fix(nono): downloads.claude.ai を auto-update 用に allow_domain へ追加

### DIFF
--- a/dot_config/nono/profiles/claude-seal.json
+++ b/dot_config/nono/profiles/claude-seal.json
@@ -95,7 +95,8 @@
       "cdn.playwright.dev",
       "storage.googleapis.com",
       "code.claude.com",
-      "docs.anthropic.com"
+      "docs.anthropic.com",
+      "downloads.claude.ai"
     ],
     "open_port": [0]
   },


### PR DESCRIPTION
## Summary
- nono sandbox 内で `claude` を起動すると `Auto-update failed` と表示される不具合を修正
- 根本原因: Claude Code のネイティブ auto-updater が接続する `downloads.claude.ai` が `claude-seal.json` の `network.allow_domain` に含まれておらず、nono のプロキシが `proxy_filtered` で拒否していた
- `dot_config/nono/profiles/claude-seal.json` の `network.allow_domain` に `downloads.claude.ai` を追加

## Test plan
- [x] `nono why --host downloads.claude.ai` が一時テストプロファイル経由で `DENIED (proxy_filtered)` → `ALLOWED (proxy_allowed)` に変化することを確認
- [x] 同テストプロファイル経由で実際に `claude update` を実行し、`Claude Code is up to date` (exit 0) を確認(修正前は `Failed to fetch version ... Socket is closed` で exit 1)
- [x] `make oxfmt` / `make test-nono-profile` / `make lint` すべて PASS
- [ ] マージ後、`chezmoi apply` を実行して本番の nono プロファイルに反映されることを確認(本リポジトリの仕様上、`chezmoi apply` は常に `main` ブランチのソースを読むため、マージまでは live には反映されない)

🤖 Generated with [Claude Code](https://claude.com/claude-code)