### PR TITLE
feat(claude): shell scriptルールをchezmoi管理下に追加

### DIFF
--- a/dot_claude/rules/common/shell-scripting.md
+++ b/dot_claude/rules/common/shell-scripting.md
@@ -1,0 +1,53 @@
+---
+date: 2026-07-29
+trigger: "エージェントが bash 3.2 で壊れるシェルスクリプトを書いた（`$VAR` 直後の非ASCII 文字、bash 4 以降専用構文）"
+paths:
+  - "*.sh"
+  - "*.sh.tmpl"
+---
+
+# シェルスクリプト
+
+## `$VAR` の直後に非ASCII 文字を置かない — `${VAR}` で囲む
+
+日本語メッセージに変数を埋めるときは必ず `${VAR}` の形で囲む。
+
+**誤:** `echo "対象は $COUNT件です"`
+**正:** `echo "対象は ${COUNT}件です"`
+
+**理由:** bash 3.2（macOS の `/bin/bash` 既定）は変数名のパースでマルチバイト文字を吸収するため、
+`$COUNT件` は「`COUNT件` という別の変数」への参照になる。`set -u` 下では
+`unbound variable` で即死し、そうでなければ**空文字に展開されて静かに壊れる**。
+
+```console
+$ /bin/bash -c 'set -u; C=3; echo "$C件"'
+/bin/bash: C\xe4: unbound variable
+$ /bin/bash -c 'set -u; C=3; echo "${C}件"'
+3件
+```
+
+**気づきにくい理由:** bash 5（Linux / CI / homebrew の bash）では再現しない。CI が緑でも
+開発機の macOS で落ちる。しかも該当の `echo` に到達した実行だけが落ちるので、
+条件分岐の中にあると忘れられたまま残る。
+
+**適用範囲:** 日本語（およびあらゆる非ASCII）を含むシェルスクリプト全般。`${VAR}` で囲むコストは
+ゼロなので、直後が ASCII かどうかを判断するより「メッセージ内の変数は常に `${}`」で統一するほうが安い。
+`*.sh.tmpl` のようにテンプレート拡張子が付いたシェルスクリプトも対象 — こちらは shellcheck が
+構文を解釈できず lint 対象から外れるため、下記の機械チェックが唯一の防波堤になる。
+
+**機械チェック:**
+
+```bash
+perl -ne 'next if /^\s*#/; while (/\$([A-Za-z_][A-Za-z0-9_]*)(?=[^\x00-\x7F])/g) { print "$ARGV: $&\n" } close ARGV if eof' path/to/*.sh
+```
+
+実例: `tanomu-verify` スキルの `scripts/selftest.sh` がこのチェックを回帰テストとして持っている。
+
+## macOS の bash 3.2 で使えない構文を避ける
+
+同じ「開発機だけで落ちる」型の落とし穴。`mapfile` / `readarray`、連想配列（`declare -A`）、
+`${var^^}` / `${var,,}`（大文字小文字変換）は bash 4 以降の機能で、macOS 標準の bash では動かない。
+`while IFS= read -r` ループや `tr` で代替する。
+
+`set -u` 下では**空配列の展開**も bash 3.2 ではエラーになる（`"${ARR[@]}"` が
+`unbound variable`）。空になりうる配列は要素数を確認してから展開するか、配列を使わない形に倒す。


### PR DESCRIPTION
## 概要

`~/.claude/rules/common/shell-scripting.md` を chezmoi 管理下に追加し、マシン間で共有・バージョン管理できるようにする。

内容は bash 3.2（macOS の `/bin/bash` 既定）でだけ壊れるシェルスクリプトの落とし穴:

- **`$VAR` の直後に非ASCII 文字を置かない** — bash 3.2 は変数名のパースでマルチバイト文字を吸収するため、`$COUNT件` は「`COUNT件` という別変数」への参照になる。`set -u` 下では `unbound variable` で即死し、そうでなければ空文字に展開されて静かに壊れる
- **bash 4 以降専用構文を避ける** — `mapfile` / `readarray`、連想配列（`declare -A`）、`${var^^}` / `${var,,}`、`set -u` 下の空配列展開

どちらも bash 5（Linux / CI / homebrew の bash）では再現しないため、**CI が緑でも開発機の macOS で落ちる**という気づきにくい失敗形をとる。

## 変更点

- `dot_claude/rules/common/shell-scripting.md` を新規追加 → `~/.claude/rules/common/shell-scripting.md`
- frontmatter は `common/` 配下の既存3ファイル（`documentation-language.md` / `github-actions.md` / `harness-engineering.md`）の規約に合わせて `trigger:` を付与
- `paths` には `*.sh` に加えて `*.sh.tmpl` も含める — テンプレート拡張子付きのシェルスクリプトは shellcheck / shfmt が構文を解釈できず lint 対象から外れる（CLAUDE.md の既知の制約）ため、ルールによる予防の価値が最も高い対象になる。同趣旨を本文の「適用範囲」にも追記した

## テスト

- ルール内の perl 機械チェックをリポジトリ内の `*.sh` / `*.sh.tmpl` / `dot_claude/scripts/*` に適用 → 違反ゼロ
- `make lint` PASS（`check-templates` / `scan-sensitive` 含む）
- prek pre-commit フック通過（secretlint / scan-sensitive）
- `chezmoi managed --source "$(pwd)"` に `.claude/rules/common/shell-scripting.md` が出ることを確認

## 補足

worktree 作業のため `chezmoi add` は使わず（`main` 固定の `~/.local/share/chezmoi` に書き込んでしまう）、ソースディレクトリへ直接コピーした。ソースを正として `~/` にもコピーバック済みなので、マージ後の `chezmoi apply` で差分は出ない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)