### PR TITLE
feat: 公式code-reviewプラグインを有効化

### DIFF
--- a/dot_claude/settings.json.tmpl
+++ b/dot_claude/settings.json.tmpl
@@ -245,6 +245,7 @@
     "claude-md-management@claude-plugins-official": true,
     "skill-creator@claude-plugins-official": true,
     "sentry@claude-plugins-official": true,
+    "code-review@claude-plugins-official": true,
     "compound-engineering@compound-engineering-plugin": true,
     "ecc@ecc": true,
     "cclens@cclens": true


### PR DESCRIPTION
## Summary
- ai-code-review スキルで ecc:code-review と併用するため、claude-plugins-official 提供の公式 code-review プラグインを enabledPlugins に追加

## Test plan
- [ ] `chezmoi diff` が空であることを確認済み
- [ ] 次回セッションで `Skill` ツールの一覧に公式 code-review プラグインが出現することを確認