### PR TITLE
feat: humanlayer/skillsマーケットプレイスからshow-meスキルを有効化

### DIFF
--- a/dot_claude/settings.json.tmpl
+++ b/dot_claude/settings.json.tmpl
@@ -248,7 +248,8 @@
     "code-review@claude-plugins-official": true,
     "compound-engineering@compound-engineering-plugin": true,
     "ecc@ecc": true,
-    "cclens@cclens": true
+    "cclens@cclens": true,
+    "show-me@skills": true
   },
   "extraKnownMarketplaces": {
     "claude-plugins-official": {
@@ -275,6 +276,12 @@
       "source": {
         "source": "github",
         "repo": "lambdalisue/cclens"
+      }
+    },
+    "skills": {
+      "source": {
+        "source": "github",
+        "repo": "humanlayer/skills"
       }
     }
   },


### PR DESCRIPTION
## Summary
- [humanlayer/skills](https://github.com/humanlayer/skills/tree/main/plugins/show-me) の `show-me` スキルを有効化
- `dot_claude/settings.json.tmpl` の `extraKnownMarketplaces` に `skills`（`humanlayer/skills` の `marketplace.json` 内 `name` フィールドと一致させたキー。既存の `cclens`/`claude-plugins-official` と同じ命名規則）を追加
- `enabledPlugins` に `show-me@skills` を追加

## 反映手順（マージ後、手動で1回のみ）
このリポジトリでは Skill/plugin 管理は APM ではなく Claude Code のネイティブマーケットプレイス機構に依っており、`extraKnownMarketplaces` の登録だけではマーケットプレイスの取得は行われない（意図的な設計）。マージ後、各マシンで以下を一度実行する必要がある:

```sh
chezmoi apply
claude plugin marketplace add humanlayer/skills
```

## Test plan
- [x] `just check-templates` — テンプレートのレンダリング検証をパス
- [x] `just oxfmt` — JSON フォーマットチェックをパス
- [ ] マージ後、`chezmoi apply` → `claude plugin marketplace add humanlayer/skills` を実行し、`/show-me` スキルが実際に呼び出せることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)