### PR TITLE
chore(claude): enabledPluginsにpr-review-toolkitを追加

### DIFF
--- a/dot_claude/settings.json.tmpl
+++ b/dot_claude/settings.json.tmpl
@@ -249,6 +249,7 @@
     "compound-engineering@compound-engineering-plugin": true,
     "ecc@ecc": true,
     "cclens@cclens": true,
+    "pr-review-toolkit@claude-plugins-official": true,
     "show-me@skills": true
   },
   "extraKnownMarketplaces": {


### PR DESCRIPTION
## Summary
- `~/.claude/settings.json` に手動で追加されていた `pr-review-toolkit@claude-plugins-official: true` を `dot_claude/settings.json.tmpl` の `enabledPlugins` に取り込み、`chezmoi apply` で消えないようにする

## Test plan
- [x] `just check-templates` 通過
- [x] `just oxfmt` 通過
- [x] `chezmoi diff` (jq正規化済み) でdriftが解消されていることを確認