### PR TITLE
fix(claude): SessionStartのorca hookとathena ask権限のドリフトをsourceに反映

### DIFF
--- a/dot_claude/settings.json.tmpl
+++ b/dot_claude/settings.json.tmpl
@@ -148,6 +148,7 @@
     {{/* Package/module install gate: installing new code is a supply-chain event, so it goes through a human. Precedence is deny > ask > allow, so the broad Bash(npm:*)/Bash(pnpm:*)/Bash(mise:*) entries in allow stay and these narrower ask entries win. Two deliberate holes: (1) Claude Code permissions match the Bash string the agent issues, NOT its subprocesses — `just lint` (Bash(just:*), still in allow) invokes pnpm without prompting; acceptable because just recipes are version-controlled and reviewable. (2) Lockfile restore (bare `pnpm install`, `npm ci`) is gated too, deliberately: splitting "new deps ask, restore allow" is an illusory boundary because an agent can edit package.json then run bare `pnpm install` straight through it. curl/wget moved from deny to ask (2026-08-01): they were previously hard-blocked to close `curl … | sh`, but that also blocked legitimate one-off downloads/API calls. ask still requires explicit approval per invocation, so `curl … | sh` is not silently executable — the boundary is now human review instead of a hard block. */ -}}
     {{/* ask fires even under bypassPermissions and takes precedence over allow (deny > ask > allow). Gate push + history-altering git behind explicit approval; locally-reversible writes (commit/merge/revert) and routine writes (add/checkout/fetch/pull/submodule/worktree) stay in allow so unattended runs don't deadlock on the prompt. push stays gated because the force-push deny rules are prefix-only: trailing-flag force (git push origin main --force), +refspec, and --delete/:branch all evade them, so push is not append-only. gh: gate state-changing subcommands (create/edit/merge/close/delete/run/set) — enumerated at the verb level because gh nests read and write under the same noun (gh pr view is read, gh pr create is write), so a noun-level gh pr:* wildcard would over-gate reads. Read-only gh (pr view/reviews, and unlisted read verbs under defaultMode) stays frictionless, and gh pr/issue comment sit in allow (append-only to an existing PR/issue). gh repo delete/archive are NOT here — they sit in deny (irreversible, no click-through). gh secret set / gh variable set are ask-gated only: the PostToolUse secretlint hook matches Write to *.env/*secret* files, not Bash gh command strings, so a secret passed inline (gh secret set NAME --body <value>) is NOT scanned and lands in shell history/transcripts — prefer --body-file/stdin and rely on prompt-time review. gh api is left unlisted: its read/write intent lives in --method, not a fixed prefix, so it can't be prefix-gated cleanly. */ -}}
     "ask": [
+      "Bash(aws athena start-query-execution:*)",
       "Bash(brew bundle:*)",
       "Bash(brew install:*)",
       "Bash(brew tap:*)",
@@ -298,6 +299,15 @@
           {
             "type": "command",
             "command": "bash -c 'mkdir -p \"$HOME/.claude/logs\" && \"$HOME/.claude/scripts/harness-briefing.sh\" 2>>\"$HOME/.claude/logs/harness-errors.log\" || true'"
+          }
+        ]
+      },
+      {
+        "hooks": [
+          {
+            "command": "if [ -f '{{ .chezmoi.homeDir }}/.orca/agent-hooks/claude-hook.sh' ] && [ -r '{{ .chezmoi.homeDir }}/.orca/agent-hooks/claude-hook.sh' ] && [ -x '{{ .chezmoi.homeDir }}/.orca/agent-hooks/claude-hook.sh' ]; then /bin/sh '{{ .chezmoi.homeDir }}/.orca/agent-hooks/claude-hook.sh'; else { command -p cat 2>/dev/null || cat; } >/dev/null 2>&1 || :; fi",
+            "timeout": 10,
+            "type": "command"
           }
         ]
       }


### PR DESCRIPTION
## Summary
- \`chezmoi-adopt-drift\` スキルで \`~/.claude/settings.json\` のドリフトを検出し、ユーザーが採用すると選んだ2件をsourceに反映
  - \`SessionStart\`(\`startup|resume|clear\`)にorca agent-hooksディスパッチャーを追加(PostToolUse/Stop/UserPromptSubmit/PreToolUseには既にあったが\`SessionStart\`だけ抜けていた)
  - \`ask\` permissionsに \`Bash(aws athena start-query-execution:*)\` を追加
- 同時に検出した \`.gitignore\` のドリフト(includeIf方式の5項目除外をanchoring注記+2項目に書き換える手動編集)は、直近実装したばかりの機構と矛盾するためユーザー判断で不採用とし、sourceは変更していない(次回applyで元に戻る)

## Test plan
- [x] \`chezmoi execute-template\` でレンダリングしJSONとして valid であることを確認
- [x] \`chezmoi diff\` で採用した2箇所のドリフトが解消されていることを確認
- [ ] マージ後 \`chezmoi apply\` で実機に反映されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)